### PR TITLE
Read the ids an in-memory index answers through a typed accessor

### DIFF
--- a/meos/examples/rtree_example.c
+++ b/meos/examples/rtree_example.c
@@ -105,7 +105,8 @@ verify_search(const char *name, const RTree *rtree, IndexSearchOp op,
   bool *indexed = calloc(NUM_BBOX, sizeof(bool));
   for (int i = 0; i < index_count; i++)
   {
-    int64 id = *(int64 *) meos_array_get(ids, i);
+    int64 id;
+    index_result_id(ids, i, &id);
     indexed[id] = true;
   }
 
@@ -391,7 +392,7 @@ int main(void)
   printf("RTree index test (%d boxes per type)\n", NUM_BBOX);
 
   /* Create a single MeosArray and reuse it across all searches */
-  MeosArray *ids = meos_array_create(sizeof(int64));
+  MeosArray *ids = index_result_create();
   test_floatspan(ids);
   test_tstzspan(ids);
   test_tbox(ids);

--- a/meos/examples/rtree_mest_example.c
+++ b/meos/examples/rtree_mest_example.c
@@ -231,7 +231,7 @@ int main(void)
   }
 
   /* Result array reused across searches */
-  MeosArray *ids = meos_array_create(sizeof(int64));
+  MeosArray *ids = index_result_create();
 
   /* Aggregated totals over all queries */
   long total_truth = 0;
@@ -273,7 +273,8 @@ int main(void)
     int single_fp = 0;
     for (int k = 0; k < single_count; k++)
     {
-      int64 id = *(int64 *) meos_array_get(ids, k);
+      int64 id;
+      index_result_id(ids, k, &id);
       assert(! seen[id]);
       seen[id] = true;
       if (! truth[id])
@@ -292,7 +293,8 @@ int main(void)
     assert(deg_count == single_count);
     for (int k = 0; k < deg_count; k++)
     {
-      int64 id = *(int64 *) meos_array_get(ids, k);
+      int64 id;
+      index_result_id(ids, k, &id);
       assert(seen[id]);
     }
 
@@ -308,7 +310,8 @@ int main(void)
       int mest_fp = 0;
       for (int k = 0; k < cand; k++)
       {
-        int64 id = *(int64 *) meos_array_get(ids, k);
+        int64 id;
+        index_result_id(ids, k, &id);
         /* Invariant (ii): dedup, each id appears at most once */
         assert(! seen[id]);
         seen[id] = true;

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -395,6 +395,11 @@ typedef enum
   INDEX_ADJACENT       /**< Find stored boxes that share a boundary with the query */
 } IndexSearchOp;
 
+/* Functions for the ids an in-memory index answers */
+
+extern MeosArray *index_result_create(void);
+extern bool index_result_id(const MeosArray *result, int n, int64 *id);
+
 /**
  * Structure for the in-memory Rtree index
  */

--- a/meos/include/meos_internal.h
+++ b/meos/include/meos_internal.h
@@ -712,6 +712,14 @@ typedef struct MeosArray
   void *elems;      /**< Pointer to the array elements */
 } MeosArray;
 
+/**
+ * @brief Return the n-th id, 0-based, of an array collecting the ids an
+ * in-memory index answers
+ * @note Internal counterpart of #index_result_id, for a caller holding an
+ * array made by #index_result_create and a position below its count
+ */
+#define INDEX_RESULT_ID_N(result, n) (((const int64 *) (result)->elems)[(n)])
+
 
 /*****************************************************************************/
 
@@ -953,6 +961,7 @@ extern bool ensure_bbox_temporal_compatible(MeosType bboxtype,
   const Temporal *temp);
 extern bool ensure_same_index_bboxtype(MeosType bboxtype1, MeosType bboxtype2);
 extern bool ensure_index_join_op(IndexSearchOp op);
+extern bool ensure_index_result(const MeosArray *result);
 extern void *bbox_temporal_split_boxes(MeosType bboxtype, size_t boxsize,
   const Temporal *temp, int maxboxes, int *count);
 

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -806,7 +806,7 @@ tcbuffer_disc_within_dist(double cx, double cy, double r, double dist,
   for (int j = 0; j < nc; j++)
   {
     const DistEdge *ed =
-      &g->segs[*(int64 *) meos_array_get(dist_pip_results, j)];
+      &g->segs[INDEX_RESULT_ID_N(dist_pip_results, j)];
     if (box2d_distance_sqr(ed->xmin, ed->ymin, ed->xmax, ed->ymax, sxmin,
         symin, sxmax, symax) > dist2)
       continue;
@@ -1055,7 +1055,7 @@ tcbuffer_geo_ctx_make(const GSERIALIZED *gs)
     0, dist_geom_build_rtree(segs, n) };
   /* Scratch buffer for the R-tree candidate ids, created with the R-tree and
    * freed with it in #tcbuffer_geo_ctx_free (see dist_pip_results). */
-  dist_pip_results = meos_array_create(sizeof(int64));
+  dist_pip_results = index_result_create();
   return ctx;
 }
 
@@ -1325,7 +1325,7 @@ tcbufferseg_within_ctx(const Cbuffer *cb1, const Cbuffer *cb2, double dist,
   for (int j = 0; j < ncand; j++)
   {
     const DistEdge *ed =
-      &ctx->g.segs[*(int64 *) meos_array_get(dist_pip_results, j)];
+      &ctx->g.segs[INDEX_RESULT_ID_N(dist_pip_results, j)];
     if (box2d_distance_sqr(ed->xmin, ed->ymin, ed->xmax, ed->ymax, cxmin,
         cymin, cxmax, cymax) > reach2)
       continue;
@@ -1420,7 +1420,7 @@ tcbuffer_disc_signed_boundary(double cx, double cy, double r,
   for (int j = 0; j < nc; j++)
   {
     const DistEdge *ed =
-      &g->segs[*(int64 *) meos_array_get(dist_pip_results, j)];
+      &g->segs[INDEX_RESULT_ID_N(dist_pip_results, j)];
     if (box2d_distance_sqr(ed->xmin, ed->ymin, ed->xmax, ed->ymax, cx, cy,
         cx, cy) > reach2)
       continue;
@@ -1530,7 +1530,7 @@ tcbufferseg_sg_roots(const Cbuffer *cb1, const Cbuffer *cb2,
   for (int j = 0; j < ncand; j++)
   {
     const DistEdge *ed =
-      &ctx->g.segs[*(int64 *) meos_array_get(dist_pip_results, j)];
+      &ctx->g.segs[INDEX_RESULT_ID_N(dist_pip_results, j)];
     if (box2d_distance_sqr(ed->xmin, ed->ymin, ed->xmax, ed->ymax, cxmin,
         cymin, cxmax, cymax) > rmax2)
       continue;

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -3804,12 +3804,12 @@ relate_point_on_boundary_index(double x, double y, const RelateEdges *re)
   STBox query;
   stbox_set(true, false, false, 0, x - re->tol, x + re->tol, y - re->tol,
     y + re->tol, 0, 0, NULL, &query);
-  MeosArray *candidates = meos_array_create(sizeof(int64));
+  MeosArray *candidates = index_result_create();
   int nc = rtree_search(re->index, INDEX_OVERLAPS, &query, candidates);
   bool result = false;
   for (int c = 0; c < nc && ! result; c++)
   {
-    Edge *one = re->edges[*(int64 *) meos_array_get(candidates, c)];
+    Edge *one = re->edges[INDEX_RESULT_ID_N(candidates, c)];
     result = relate_point_on_boundary(x, y, &one, 1);
   }
   meos_array_destroy(candidates);
@@ -6076,12 +6076,12 @@ relate_area_edge_intervals(const Edge *edge, const RelateEdges *other,
     double pad = fmax(other->tol, edge->tol);
     stbox_set(true, false, false, 0, edge->xmin - pad, edge->xmax + pad,
       edge->ymin - pad, edge->ymax + pad, 0, 0, NULL, &query);
-    candidates = meos_array_create(sizeof(int64));
+    candidates = index_result_create();
     ncand = rtree_search(other->index, INDEX_OVERLAPS, &query, candidates);
   }
   for (int c = 0; c < ncand; c++)
   {
-    int j = candidates ? (int) *(int64 *) meos_array_get(candidates, c) : c;
+    int j = candidates ? (int) INDEX_RESULT_ID_N(candidates, c) : c;
     const Edge *oedge = other->edges[j];
     if (! relate_area_boundary_edge(oedge))
       continue;
@@ -6219,7 +6219,7 @@ relate_area_boundary_points(const RelateEdges *are, const RelateEdges *bre,
 {
   Edge **aedges = are->edges, **bedges = bre->edges;
   int na = are->nedges, nb = bre->nedges;
-  MeosArray *candidates = bre->index ? meos_array_create(sizeof(int64)) : NULL;
+  MeosArray *candidates = bre->index ? index_result_create() : NULL;
   for (int i = 0; i < na; i++)
   {
     const Edge *a = aedges[i];
@@ -6240,7 +6240,7 @@ relate_area_boundary_points(const RelateEdges *are, const RelateEdges *bre,
     }
     for (int c = 0; c < ncand; c++)
     {
-      int j = candidates ? (int) *(int64 *) meos_array_get(candidates, c) : c;
+      int j = candidates ? (int) INDEX_RESULT_ID_N(candidates, c) : c;
       const Edge *b = bedges[j];
       if (!relate_area_boundary_edge(b))
         continue;
@@ -6450,12 +6450,12 @@ relate_area_boundaries_cross(const RelateEdges *a, const RelateEdges *b)
     STBox query;
     stbox_set(true, false, false, 0, ea->xmin, ea->xmax, ea->ymin, ea->ymax,
       0, 0, NULL, &query);
-    MeosArray *candidates = meos_array_create(sizeof(int64));
+    MeosArray *candidates = index_result_create();
     int nc = rtree_search(b->index, INDEX_OVERLAPS, &query, candidates);
     bool result = false;
     for (int c = 0; c < nc && ! result; c++)
     {
-      const Edge *eb = b->edges[*(int64 *) meos_array_get(candidates, c)];
+      const Edge *eb = b->edges[INDEX_RESULT_ID_N(candidates, c)];
       result = relate_area_edges_cross(ea, eb);
     }
     meos_array_destroy(candidates);
@@ -6776,7 +6776,7 @@ relate_clearance(double x, double y, const RelateComp *comps, int ncomp,
     indexed = (comps[i].re.index != NULL);
   if (indexed)
   {
-    MeosArray *candidates = meos_array_create(sizeof(int64));
+    MeosArray *candidates = index_result_create();
     double r = seed > MEOS_GEOM_TOLERANCE ? seed : MEOS_GEOM_TOLERANCE;
     for (int round = 0; round < 64; round++)
     {
@@ -6790,7 +6790,7 @@ relate_clearance(double x, double y, const RelateComp *comps, int ncomp,
           candidates);
         for (int c = 0; c < nc; c++)
         {
-          int j = (int) *(int64 *) meos_array_get(candidates, c);
+          int j = (int) INDEX_RESULT_ID_N(candidates, c);
           double d = relate_edge_distance(x, y, comps[i].edges[j]);
           /* An edge the point LIES ON is no clearance from it. What the
            * distance misses the edge by is a property of the arithmetic --
@@ -6979,7 +6979,7 @@ relate_union_edges(const LWGEOM *geom)
     edges[i] = (Edge *) meos_array_get(all, i);
   RelateEdges re;
   relate_edges_init(&re, edges, nall, index);
-  MeosArray *candidates = re.index ? meos_array_create(sizeof(int64)) : NULL;
+  MeosArray *candidates = re.index ? index_result_create() : NULL;
   for (int i = 0; i < nall; i++)
   {
     Edge *e = edges[i];
@@ -7006,7 +7006,7 @@ relate_union_edges(const LWGEOM *geom)
     }
     for (int c = 0; c < ncand; c++)
     {
-      int j = candidates ? (int) *(int64 *) meos_array_get(candidates, c) : c;
+      int j = candidates ? (int) INDEX_RESULT_ID_N(candidates, c) : c;
       const Edge *other = edges[j];
       if (j == i || ! relate_area_boundary_edge(other))
         continue;
@@ -7790,13 +7790,13 @@ relate_edges_meet_any(const Edge *a, const RelateEdges *other)
     }
     return false;
   }
-  MeosArray *candidates = meos_array_create(sizeof(int64));
+  MeosArray *candidates = index_result_create();
   int nc = relate_edges_candidates(other, a->xmin, a->xmax, a->ymin, a->ymax,
     candidates);
   bool result = false;
   for (int c = 0; c < nc && ! result; c++)
   {
-    const Edge *b = other->edges[*(int64 *) meos_array_get(candidates, c)];
+    const Edge *b = other->edges[INDEX_RESULT_ID_N(candidates, c)];
     if (b->etype == EDGE_POINT)
       continue;
     /* The index query is grown by the widest tolerance the array asks for,
@@ -7829,12 +7829,12 @@ relate_point_on_any_edge(double x, double y, const RelateEdges *other)
         return true;
     return false;
   }
-  MeosArray *candidates = meos_array_create(sizeof(int64));
+  MeosArray *candidates = index_result_create();
   int nc = relate_edges_candidates(other, x, x, y, y, candidates);
   bool result = false;
   for (int c = 0; c < nc && ! result; c++)
     result = relate_point_on_edge(x, y,
-      other->edges[*(int64 *) meos_array_get(candidates, c)]);
+      other->edges[INDEX_RESULT_ID_N(candidates, c)]);
   meos_array_destroy(candidates);
   return result;
 }
@@ -8791,7 +8791,7 @@ linear_union_dissolve_edges(const MeosArray *edges, int32_t srid,
       NULL, &box);
     rtree_insert(rtree, &box, i);
   }
-  MeosArray *found = meos_array_create(sizeof(int64));
+  MeosArray *found = index_result_create();
   int *which = palloc(sizeof(int) * (size_t) (nedges + 1));
   LinearStretch *cover = palloc(sizeof(LinearStretch) * (size_t) (nedges + 1));
   int maxpieces = nedges + 1, npieces = 0;
@@ -8807,7 +8807,7 @@ linear_union_dissolve_edges(const MeosArray *edges, int32_t srid,
     int nwhich = 0;
     for (int f = 0; f < nfound; f++)
     {
-      int j = (int) *(int64 *) meos_array_get(found, (uint32_t) f);
+      int j = (int) INDEX_RESULT_ID_N(found, (uint32_t) f);
       if (j < i)
         which[nwhich++] = j;
     }

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2243,7 +2243,7 @@ geom_areal_touching_stretches(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 
   LWGEOM **lines = palloc(sizeof(LWGEOM *) * 64);
   int nlines = 0, maxlines = 64;
-  MeosArray *candidates = index ? meos_array_create(sizeof(int64)) : NULL;
+  MeosArray *candidates = index ? index_result_create() : NULL;
   for (int i = 0; i < n1; i++)
   {
     const WoundSeg *a = &s1[i];
@@ -2269,7 +2269,7 @@ geom_areal_touching_stretches(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 
     for (int c = 0; c < ncand; c++)
     {
-      int j = index ? (int) *(int64 *) meos_array_get(candidates, c) : c;
+      int j = index ? (int) INDEX_RESULT_ID_N(candidates, c) : c;
       const WoundSeg *b = &s2[j];
       /* The boxes decide all but a handful of pairs, and the kernel is what
        * the walk would otherwise spend its time in */

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -1014,7 +1014,7 @@ dist_geom_point_inside(double x, double y, const DistGeom *g)
     int nc = rtree_search(g->rtree, INDEX_OVERLAPS, &query, dist_pip_results);
     for (int j = 0; j < nc; j++)
       dist_poly_seg_raycross(
-        &g->segs[*(int64 *) meos_array_get(dist_pip_results, j)], x, y,
+        &g->segs[INDEX_RESULT_ID_N(dist_pip_results, j)], x, y,
         &inside);
     return inside;
   }

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -2350,7 +2350,7 @@ setset_box_pairs(const STBox *bb1, int count1, const STBox *bb2, int count2,
   for (int j = 0; j < count2; j++)
     rtree_insert(rtree2, (void *) &bb2[j], j);
 
-  MeosArray *found = meos_array_create(sizeof(int64));
+  MeosArray *found = index_result_create();
   int n = rtree_join(rtree1, rtree2, INDEX_OVERLAPS, found);
   int *result = NULL;
   if (n > 0)
@@ -2359,7 +2359,7 @@ setset_box_pairs(const STBox *bb1, int count1, const STBox *bb2, int count2,
     /* The ids are the segment positions inserted above, so they are bounded by
      * count1/count2 and the narrowing back to int is exact */
     for (int k = 0; k < 2 * n; k++)
-      result[k] = (int) *(int64 *) meos_array_get(found, k);
+      result[k] = (int) INDEX_RESULT_ID_N(found, k);
     qsort(result, (size_t) n, 2 * sizeof(int), pair_cmp);
   }
   meos_array_destroy(found);

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -141,7 +141,7 @@ point_in_polygon_impl(double x, double y, Edge **edges, int nedges,
     for (int i = 0; i < n && ! shared; i++)
     {
       const Edge *restrict e = rtree ?
-        edges[*(int64 *) meos_array_get(rtree_results, i)] : edges[i];
+        edges[INDEX_RESULT_ID_N(rtree_results, i)] : edges[i];
 
       /* Only polygon boundary edges bound a region. Point, line, and
        * standalone (1D) arc edges are ignored by the even-odd containment
@@ -258,7 +258,7 @@ point_in_polygon_index(double x, double y, Edge **edges, int nedges,
    * context otherwise owns. A caller outside that context finds it empty, and
    * an empty one is what the search would read through */
   if (rtree && ! rtree_results)
-    rtree_results = meos_array_create(sizeof(int64));
+    rtree_results = index_result_create();
   return point_in_polygon_impl(x, y, edges, nedges, rtree, xmax);
 }
 
@@ -735,7 +735,7 @@ tpointinst_clip_edges(const TInstant *inst, Edge **edges, int nedges,
 
     /* Convert the result of an R-tree look up into an edge pointer array */
     for (int j = 0; j < cand_nedges; j++)
-      cand_edges[j] = edges[*(int64 *) meos_array_get(rtree_results, j)];
+      cand_edges[j] = edges[INDEX_RESULT_ID_N(rtree_results, j)];
     sel_edges = cand_edges;
     sel_nedges = cand_nedges;
   }
@@ -813,7 +813,7 @@ tpointseq_clip_edges(const TSequence *seq, Edge **edges, int nedges,
 
       /* Convert the result of an R-tree look up into an edge pointer array */
       for (int j = 0; j < cand_nedges; j++)
-        cand_edges[j] = edges[*(int64 *) meos_array_get(rtree_results, j)];
+        cand_edges[j] = edges[INDEX_RESULT_ID_N(rtree_results, j)];
       sel_edges = cand_edges;
       sel_nedges = cand_nedges;
     }
@@ -965,7 +965,7 @@ geo_edge_ctx_make(const GSERIALIZED *gs)
     }
     ctx->cand_edges = palloc(sizeof(Edge *) * ctx->nedges);
     /* Array for collecting the ids resulting from an R-tree search */
-    rtree_results = meos_array_create(sizeof(int64));
+    rtree_results = index_result_create();
   }
   return ctx;
 }
@@ -1754,7 +1754,7 @@ geo_clip_linear_geom(const GSERIALIZED *line, const GSERIALIZED *gs,
           rtree_results);
         for (int k = 0; k < nc; k++)
           ctx->cand_edges[k] =
-            ctx->edge_ptrs[*(int64 *) meos_array_get(rtree_results, k)];
+            ctx->edge_ptrs[INDEX_RESULT_ID_N(rtree_results, k)];
         sel = ctx->cand_edges; seln = nc;
       }
       intervals->count = 0;
@@ -1934,7 +1934,7 @@ geo_intersects2d_ctx(const GSERIALIZED *gs, const void *ctxv)
       int nc = rtree_search(ctx->rtree, INDEX_OVERLAPS, &query, rtree_results);
       for (int j = 0; j < nc; j++)
         ctx->cand_edges[j] =
-          ctx->edge_ptrs[*(int64 *) meos_array_get(rtree_results, j)];
+          ctx->edge_ptrs[INDEX_RESULT_ID_N(rtree_results, j)];
       for (int j = 0; j < nc && ! result; j++)
         if (edge_intersect(e, ctx->cand_edges[j]))
           result = true;
@@ -2503,7 +2503,7 @@ point_geom_within(double px, double py, Edge **edges, int nedges,
     int nc = rtree_search(rtree, INDEX_OVERLAPS, &query, rtree_results);
     for (int i = 0; i < nc; i++)
       if (point_edge_dist2(px, py,
-            edges[*(int64 *) meos_array_get(rtree_results, i)]) <=
+            edges[INDEX_RESULT_ID_N(rtree_results, i)]) <=
           d2 + MEOS_GEOM_TOLERANCE)
         return true;
   }
@@ -2782,7 +2782,7 @@ tpointseq_dwithin_edges(const TSequence *seq, Edge **edges, int nedges,
       int cand_nedges = rtree_search(rtree, INDEX_OVERLAPS, &query,
         rtree_results);
       for (int j = 0; j < cand_nedges; j++)
-        cand_edges[j] = edges[*(int64 *) meos_array_get(rtree_results, j)];
+        cand_edges[j] = edges[INDEX_RESULT_ID_N(rtree_results, j)];
       sel_edges = cand_edges;
       sel_nedges = cand_nedges;
     }

--- a/meos/src/temporal/temporal_boxops.c
+++ b/meos/src/temporal/temporal_boxops.c
@@ -249,6 +249,65 @@ ensure_index_join_op(IndexSearchOp op)
 }
 
 /**
+ * @brief Return true if an array holds the ids an index answers, report an
+ * error otherwise
+ * @details Shared by the in-memory RTree and SPTree indexes. A search copies
+ * each id into the array at the width of its elements, so an array of
+ * narrower elements keeps part of every id and answers another one
+ * @param[in] result Array
+ */
+bool
+ensure_index_result(const MeosArray *result)
+{
+  if (! result->varlength && result->elem_size == sizeof(int64))
+    return true;
+  meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+    "The array cannot hold the ids an index answers, create it with "
+    "index_result_create");
+  return false;
+}
+
+/**
+ * @ingroup meos_temporal_box_index
+ * @brief Return an array collecting the ids an in-memory index answers
+ * @details A search or a join of an RTree or an SPTree fills the array, and
+ * #index_result_id reads an id back. The array can be reused across searches,
+ * each of which resets it
+ * @return New array
+ * @errval NULL
+ */
+MeosArray *
+index_result_create(void)
+{
+  return meos_array_create(sizeof(int64));
+}
+
+/**
+ * @ingroup meos_temporal_box_index
+ * @brief Return in the last argument the n-th id, 0-based, an in-memory index
+ * answers
+ * @details A join answers two ids per pair, so pair `k` is read at positions
+ * `2 * k` and `2 * k + 1`
+ * @param[in] result Array filled by a search or a join
+ * @param[in] n Position of the id
+ * @param[out] id Id
+ * @return Return true if the id is found
+ */
+bool
+index_result_id(const MeosArray *result, int n, int64 *id)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(result, false); VALIDATE_NOT_NULL(id, false);
+  if (! ensure_index_result(result))
+    return false;
+  const int64 *slot = meos_array_get(result, n);
+  if (! slot)
+    return false;
+  *id = *slot;
+  return true;
+}
+
+/**
  * @brief Decompose a temporal value into an array of tight per-segment
  * bounding boxes whose element type matches the given bounding box type
  * @details Shared by the in-memory RTree and SPTree indexes. The

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -1540,15 +1540,15 @@ rtree_insert(RTree *rtree, void *box, int64 id)
  * @brief Search an RTree with a bounding box, collecting matching IDs into
  * a MeosArray
  * @details The result array is reset before the search. After the call,
- * use the returned count and #meos_array_get to read the matching IDs.
+ * use the returned count and #index_result_id to read the matching IDs.
  * The same array can be reused across multiple searches without reallocating.
  * @param[in] rtree The RTree to query
  * @param[in] op The search operation: @p INDEX_OVERLAPS finds boxes that
  * overlap the query, @p INDEX_CONTAINS finds boxes that contain the query,
  * @p INDEX_CONTAINED_BY finds boxes contained by the query
  * @param[in] query The bounding box that serves as query
- * @param[out] result MeosArray of int to collect matching IDs (created by the
- * caller with `meos_array_create(sizeof(int64))`)
+ * @param[out] result Array collecting the matching ids, made by
+ * #index_result_create
  * @return Number of matching IDs
  */
 int
@@ -1558,7 +1558,7 @@ rtree_search(const RTree *rtree, IndexSearchOp op, const void *query,
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(rtree, -1); VALIDATE_NOT_NULL(query, -1);
   VALIDATE_NOT_NULL(result, -1);
-  if (! ensure_valid_rtree_box(rtree, query))
+  if (! ensure_valid_rtree_box(rtree, query) || ! ensure_index_result(result))
     return -1;
 
   meos_array_reset(result);
@@ -1577,14 +1577,13 @@ rtree_search(const RTree *rtree, IndexSearchOp op, const void *query,
  *
  * The result array is reset before the join. It receives two ids per pair, the
  * entry of @p rtree1 followed by the entry of @p rtree2, so pair `k` is read
- * with #meos_array_get at positions `2 * k` and `2 * k + 1`.
+ * with #index_result_id at positions `2 * k` and `2 * k + 1`.
  * @param[in] rtree1,rtree2 The RTrees to join, of the same bounding box type
  * @param[in] op The join operation: @p INDEX_OVERLAPS pairs entries that
  * overlap, @p INDEX_CONTAINS pairs entries of @p rtree1 that contain an entry
  * of @p rtree2, @p INDEX_CONTAINED_BY pairs entries of @p rtree1 contained by
  * an entry of @p rtree2
- * @param[out] result MeosArray of int to collect the ids (created by the caller
- * with `meos_array_create(sizeof(int64))`)
+ * @param[out] result Array collecting the ids, made by #index_result_create
  * @return Number of qualifying pairs, half the number of collected ids, on
  * error -1
  */
@@ -1596,7 +1595,8 @@ rtree_join(const RTree *rtree1, const RTree *rtree2, IndexSearchOp op,
   VALIDATE_NOT_NULL(rtree1, -1); VALIDATE_NOT_NULL(rtree2, -1);
   VALIDATE_NOT_NULL(result, -1);
   if (! ensure_same_index_bboxtype(rtree1->bboxtype, rtree2->bboxtype) ||
-      ! ensure_valid_rtree_rtree(rtree1, rtree2) || ! ensure_index_join_op(op))
+      ! ensure_valid_rtree_rtree(rtree1, rtree2) ||
+      ! ensure_index_join_op(op) || ! ensure_index_result(result))
     return -1;
 
   meos_array_reset(result);
@@ -1640,7 +1640,8 @@ rtree_insert_temporal(RTree *rtree, const Temporal *temp, int64 id)
  * @param[in] rtree The RTree to query
  * @param[in] op The search operation
  * @param[in] temp The temporal value whose bounding box serves as query
- * @param[out] result MeosArray of int to collect matching IDs
+ * @param[out] result Array collecting the matching ids, made by
+ * #index_result_create
  * @return Number of matching IDs
  */
 int
@@ -1714,6 +1715,18 @@ rtree_insert_temporal_split(RTree *rtree, const Temporal *temp, int64 id,
 }
 
 /**
+ * @brief Order two indexed ids, in the form @p qsort takes
+ * @note `int64_cmp` in type_util.c compares two `int64` values rather than two
+ * pointers to them, so it is not a `qsort` comparator
+ */
+static int
+rtree_id_cmp(const void *a, const void *b)
+{
+  int64 l = *(const int64 *) a, r = *(const int64 *) b;
+  return (l < r) ? -1 : ((l > r) ? 1 : 0);
+}
+
+/**
  * @ingroup meos_temporal_box_index
  * @brief Search an RTree built with #rtree_insert_temporal_split using a
  * temporal value, returning each matching id exactly once
@@ -1731,26 +1744,21 @@ rtree_insert_temporal_split(RTree *rtree, const Temporal *temp, int64 id,
  * queries
  * @param[in] maxboxes Maximum number of query boxes derived from `temp`;
  * values `<= 1` degenerate to a single minimum bounding box query
- * @param[out] result MeosArray of int to collect the deduplicated matching ids
+ * @param[out] result Array collecting the deduplicated matching ids, made by
+ * #index_result_create
  * @return Number of distinct matching ids
+ * @errval -1
  * @see rtree_search_temporal
  */
-/**
- * @brief Order two indexed ids, in the form @p qsort takes
- * @note `int64_cmp` in type_util.c compares two `int64` values rather than two
- * pointers to them, so it is not a `qsort` comparator
- */
-static int
-rtree_id_cmp(const void *a, const void *b)
-{
-  int64 l = *(const int64 *) a, r = *(const int64 *) b;
-  return (l < r) ? -1 : ((l > r) ? 1 : 0);
-}
-
 int
 rtree_search_temporal_dedup(const RTree *rtree, IndexSearchOp op,
   const Temporal *temp, int maxboxes, MeosArray *result)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(result, -1);
+  if (! ensure_index_result(result))
+    return -1;
+
   meos_array_reset(result);
   if (! ensure_bbox_temporal_compatible(rtree->bboxtype, temp))
     return 0;
@@ -1761,15 +1769,15 @@ rtree_search_temporal_dedup(const RTree *rtree, IndexSearchOp op,
     return 0;
 
   /* Accumulate the raw (possibly duplicated) candidate ids of every query box */
-  MeosArray *raw = meos_array_create(sizeof(int64));
-  MeosArray *hits = meos_array_create(sizeof(int64));
+  MeosArray *raw = index_result_create();
+  MeosArray *hits = index_result_create();
   for (int i = 0; i < count; i++)
   {
     int nhits = rtree_search(rtree, op,
       (char *) boxes + (size_t) i * rtree->bboxsize, hits);
     for (int j = 0; j < nhits; j++)
     {
-      int64 id = *(int64 *) meos_array_get(hits, j);
+      int64 id = INDEX_RESULT_ID_N(hits, j);
       meos_array_add(raw, &id);
     }
   }
@@ -1786,7 +1794,7 @@ rtree_search_temporal_dedup(const RTree *rtree, IndexSearchOp op,
   {
     int64 *ids = palloc((size_t) nraw * sizeof(int64));
     for (int i = 0; i < nraw; i++)
-      ids[i] = *(int64 *) meos_array_get(raw, i);
+      ids[i] = INDEX_RESULT_ID_N(raw, i);
     qsort(ids, (size_t) nraw, sizeof(int64), rtree_id_cmp);
     for (int i = 0; i < nraw; i++)
       if (i == 0 || ids[i] != ids[i - 1])

--- a/meos/src/temporal/temporal_sptree.c
+++ b/meos/src/temporal/temporal_sptree.c
@@ -1087,7 +1087,8 @@ spnode_search(const SPTree *sptree, const SPNode *node, const void *nodebox,
  * overlap the query, @p INDEX_CONTAINS finds boxes that contain the query,
  * @p INDEX_CONTAINED_BY finds boxes contained by the query
  * @param[in] query The bounding box that serves as query
- * @param[out] result MeosArray of int to collect matching ids
+ * @param[out] result Array collecting the matching ids, made by
+ * #index_result_create
  * @return Number of matching ids
  */
 int
@@ -1097,7 +1098,7 @@ sptree_search(const SPTree *sptree, IndexSearchOp op, const void *query,
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(sptree, -1); VALIDATE_NOT_NULL(query, -1);
   VALIDATE_NOT_NULL(result, -1);
-  if (! ensure_valid_sptree_box(sptree, query))
+  if (! ensure_valid_sptree_box(sptree, query) || ! ensure_index_result(result))
     return -1;
 
   /* Project the query box into the internal box type (TPCBox: STBox) */
@@ -1175,7 +1176,7 @@ spnode_join(const SPTree *sptree1, const SPNode *node1, const SPTree *sptree2,
   for (int k = 0; k < count; k++)
   {
     int64 id1 = node1->id;
-    int64 id2 = *(int64 *) meos_array_get(found, k);
+    int64 id2 = INDEX_RESULT_ID_N(found, k);
     meos_array_add(result, &id1);
     meos_array_add(result, &id2);
   }
@@ -1201,15 +1202,14 @@ spnode_join(const SPTree *sptree1, const SPNode *node1, const SPTree *sptree2,
  *
  * The result array is reset before the join. It receives two ids per pair, the
  * entry of @p sptree1 followed by the entry of @p sptree2, so pair `k` is read
- * with #meos_array_get at positions `2 * k` and `2 * k + 1`.
+ * with #index_result_id at positions `2 * k` and `2 * k + 1`.
  * @param[in] sptree1,sptree2 The SPTrees to join, of the same bounding box
  * type. They need not be of the same kind
  * @param[in] op The join operation: @p INDEX_OVERLAPS pairs entries that
  * overlap, @p INDEX_CONTAINS pairs entries of @p sptree1 that contain an entry
  * of @p sptree2, @p INDEX_CONTAINED_BY pairs entries of @p sptree1 contained by
  * an entry of @p sptree2
- * @param[out] result MeosArray of int64 to collect the ids (created by the
- * caller with `meos_array_create(sizeof(int64))`)
+ * @param[out] result Array collecting the ids, made by #index_result_create
  * @return Number of qualifying pairs, half the number of collected ids, on
  * error -1
  */
@@ -1222,7 +1222,7 @@ sptree_join(const SPTree *sptree1, const SPTree *sptree2, IndexSearchOp op,
   VALIDATE_NOT_NULL(result, -1);
   if (! ensure_same_index_bboxtype(sptree1->bboxtype, sptree2->bboxtype) ||
       ! ensure_valid_sptree_sptree(sptree1, sptree2) ||
-      ! ensure_index_join_op(op))
+      ! ensure_index_join_op(op) || ! ensure_index_result(result))
     return -1;
 
   meos_array_reset(result);
@@ -1230,7 +1230,7 @@ sptree_join(const SPTree *sptree1, const SPTree *sptree2, IndexSearchOp op,
   {
     char rootbox2[SPTREE_NODEBOX_MAXSIZE];
     sptree2->nodebox_init(rootbox2, sptree2->root->centroid, sptree2);
-    MeosArray *found = meos_array_create(sizeof(int64));
+    MeosArray *found = index_result_create();
     spnode_join(sptree1, sptree1->root, sptree2, rootbox2,
       index_op_converse(op), found, result);
     meos_array_destroy(found);
@@ -1281,7 +1281,8 @@ sptree_insert_temporal(SPTree *sptree, const Temporal *temp, int64 id)
  * @param[in] sptree The SPTree to query
  * @param[in] op The search operation
  * @param[in] temp The temporal value whose bounding box serves as query
- * @param[out] result MeosArray of int to collect matching ids
+ * @param[out] result Array collecting the matching ids, made by
+ * #index_result_create
  * @return Number of matching ids
  */
 int
@@ -1334,6 +1335,16 @@ sptree_insert_temporal_split(SPTree *sptree, const Temporal *temp, int64 id,
 }
 
 /**
+ * @brief Order two indexed ids, in the form @p qsort takes
+ */
+static int
+sptree_id_cmp(const void *a, const void *b)
+{
+  int64 l = *(const int64 *) a, r = *(const int64 *) b;
+  return (l < r) ? -1 : ((l > r) ? 1 : 0);
+}
+
+/**
  * @ingroup meos_temporal_box_index
  * @brief Search an in-memory space-partitioning index built with
  * #sptree_insert_temporal_split using a temporal value, returning each matching
@@ -1348,24 +1359,21 @@ sptree_insert_temporal_split(SPTree *sptree, const Temporal *temp, int64 id,
  * @param[in] temp The temporal value whose per-segment bounding boxes serve as
  * queries
  * @param[in] maxboxes Maximum number of query boxes derived from `temp`
- * @param[out] result MeosArray of int to collect the deduplicated matching ids
+ * @param[out] result Array collecting the deduplicated matching ids, made by
+ * #index_result_create
  * @return Number of distinct matching ids
+ * @errval -1
  * @see sptree_search_temporal
  */
-/**
- * @brief Order two indexed ids, in the form @p qsort takes
- */
-static int
-sptree_id_cmp(const void *a, const void *b)
-{
-  int64 l = *(const int64 *) a, r = *(const int64 *) b;
-  return (l < r) ? -1 : ((l > r) ? 1 : 0);
-}
-
 int
 sptree_search_temporal_dedup(const SPTree *sptree, IndexSearchOp op,
   const Temporal *temp, int maxboxes, MeosArray *result)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(result, -1);
+  if (! ensure_index_result(result))
+    return -1;
+
   meos_array_reset(result);
   if (! ensure_bbox_temporal_compatible(sptree->bboxtype, temp))
     return 0;
@@ -1376,15 +1384,15 @@ sptree_search_temporal_dedup(const SPTree *sptree, IndexSearchOp op,
     return 0;
 
   /* Accumulate the raw (possibly duplicated) candidate ids of every query box */
-  MeosArray *raw = meos_array_create(sizeof(int64));
-  MeosArray *hits = meos_array_create(sizeof(int64));
+  MeosArray *raw = index_result_create();
+  MeosArray *hits = index_result_create();
   for (int i = 0; i < count; i++)
   {
     int nhits = sptree_search(sptree, op,
       (char *) boxes + (size_t) i * sptree->boxsize, hits);
     for (int j = 0; j < nhits; j++)
     {
-      int64 id = *(int64 *) meos_array_get(hits, j);
+      int64 id = INDEX_RESULT_ID_N(hits, j);
       meos_array_add(raw, &id);
     }
   }
@@ -1398,7 +1406,7 @@ sptree_search_temporal_dedup(const SPTree *sptree, IndexSearchOp op,
   {
     int64 *ids = palloc((size_t) nraw * sizeof(int64));
     for (int i = 0; i < nraw; i++)
-      ids[i] = *(int64 *) meos_array_get(raw, i);
+      ids[i] = INDEX_RESULT_ID_N(raw, i);
     qsort(ids, (size_t) nraw, sizeof(int64), sptree_id_cmp);
     for (int i = 0; i < nraw; i++)
       if (i == 0 || ids[i] != ids[i - 1])

--- a/meos/test/index_position_test.c
+++ b/meos/test/index_position_test.c
@@ -32,7 +32,8 @@
  * @brief A program that tests the position search operations of the in-memory
  * indexes, i.e., the operations that order a dimension, against the exact
  * answer and across both index structures, together with the equality
- * operation, which orders no dimension but is pruned the way containment is.
+ * operation, which orders no dimension but is pruned the way containment is,
+ * and the width of the ids the indexes answer.
  *
  * An index answers a position operation by two different tests: an entry is
  * accepted by the operator of the box type, and a subtree is descended when it
@@ -120,7 +121,7 @@ sorted_of(MeosArray *result, int *count)
   *count = meos_array_count(result);
   int64 *ids = malloc(sizeof(int64) * (size_t) (*count ? *count : 1));
   for (int i = 0; i < *count; i++)
-    ids[i] = *(int64 *) meos_array_get(result, i);
+    index_result_id(result, i, &ids[i]);
   qsort(ids, (size_t) *count, sizeof(int64), cmp_int64);
   return ids;
 }
@@ -178,21 +179,21 @@ main(void)
       qsort(want, (size_t) nwant, sizeof(int64), cmp_int64);
       hits += nwant;
 
-      MeosArray *r = meos_array_create(sizeof(int64));
+      MeosArray *r = index_result_create();
       rtree_search(rt, OPS[o].op, query, r);
       int n; int64 *got = sorted_of(r, &n);
       if (n != nwant || (nwant && memcmp(got, want, sizeof(int64) * (size_t) nwant)))
         wrong_rt++;
       free(got); meos_array_destroy(r);
 
-      r = meos_array_create(sizeof(int64));
+      r = index_result_create();
       sptree_search(quad, OPS[o].op, query, r);
       got = sorted_of(r, &n);
       if (n != nwant || (nwant && memcmp(got, want, sizeof(int64) * (size_t) nwant)))
         wrong_quad++;
       free(got); meos_array_destroy(r);
 
-      r = meos_array_create(sizeof(int64));
+      r = index_result_create();
       sptree_search(kd, OPS[o].op, query, r);
       got = sorted_of(r, &n);
       if (n != nwant || (nwant && memcmp(got, want, sizeof(int64) * (size_t) nwant)))
@@ -233,9 +234,9 @@ main(void)
         if (same_stbox_stbox(&boxes[i], query))
           want++;
 
-      MeosArray *got_rt = meos_array_create(sizeof(int64));
-      MeosArray *got_quad = meos_array_create(sizeof(int64));
-      MeosArray *got_kd = meos_array_create(sizeof(int64));
+      MeosArray *got_rt = index_result_create();
+      MeosArray *got_quad = index_result_create();
+      MeosArray *got_kd = index_result_create();
       int n_rt = rtree_search(rt, INDEX_SAME, query, got_rt);
       int n_quad = sptree_search(quad, INDEX_SAME, query, got_quad);
       int n_kd = sptree_search(kd, INDEX_SAME, query, got_kd);
@@ -300,9 +301,9 @@ main(void)
       sptree_insert(aquad, &chain[i], chain_ids[i]);
       sptree_insert(akd, &chain[i], chain_ids[i]);
     }
-    MeosArray *g1 = meos_array_create(sizeof(int64));
-    MeosArray *g2 = meos_array_create(sizeof(int64));
-    MeosArray *g3 = meos_array_create(sizeof(int64));
+    MeosArray *g1 = index_result_create();
+    MeosArray *g2 = index_result_create();
+    MeosArray *g3 = index_result_create();
     int n1 = rtree_search(art, INDEX_ADJACENT, query, g1);
     int n2 = sptree_search(aquad, INDEX_ADJACENT, query, g2);
     int n3 = sptree_search(akd, INDEX_ADJACENT, query, g3);
@@ -321,7 +322,7 @@ main(void)
     RTree *art2 = rtree_create_intspan();
     for (int i = 0; i < NADJ; i++)
       rtree_insert(art2, &chain[i], chain_ids[i]);
-    MeosArray *pairs = meos_array_create(sizeof(int64));
+    MeosArray *pairs = index_result_create();
     rtree_join(art, art2, INDEX_ADJACENT, pairs);
     int got_pairs = meos_array_count(pairs) / 2;
     if (got_pairs != want_pairs)
@@ -336,6 +337,57 @@ main(void)
     rtree_free(art); rtree_free(art2);
     sptree_free(aquad); sptree_free(akd);
     free(chain); free(chain_ids);
+  }
+
+  /* The ids an index answers. An id is 64 bits wide, and a search copies it
+   * into the result array at the width of the array's elements, so an id
+   * beyond 32 bits keeps its high half only in an array made for the ids. An
+   * array of narrower elements would keep the low half and answer another id,
+   * 5 for the one inserted here, so every index refuses it. */
+  {
+    const int64 big = 4294967301;
+    STBox *b = stbox_in("STBOX X((1,1),(2,2))");
+    RTree *irt = rtree_create_stbox();
+    SPTree *iquad = sptree_create_stbox(SPTREE_QUADTREE);
+    SPTree *ikd = sptree_create_stbox(SPTREE_KDTREE);
+    rtree_insert(irt, b, big);
+    sptree_insert(iquad, b, big);
+    sptree_insert(ikd, b, big);
+
+    MeosArray *res = index_result_create();
+    int64 id_rt = 0, id_quad = 0, id_kd = 0;
+    bool read_rt = rtree_search(irt, INDEX_OVERLAPS, b, res) == 1 &&
+      index_result_id(res, 0, &id_rt);
+    bool read_quad = sptree_search(iquad, INDEX_OVERLAPS, b, res) == 1 &&
+      index_result_id(res, 0, &id_quad);
+    bool read_kd = sptree_search(ikd, INDEX_OVERLAPS, b, res) == 1 &&
+      index_result_id(res, 0, &id_kd);
+    if (! read_rt || ! read_quad || ! read_kd || id_rt != big ||
+        id_quad != big || id_kd != big)
+    {
+      printf("index ids: the id %lld reads back as R-tree %lld, quad-tree "
+        "%lld, k-d tree %lld\n", (long long) big, (long long) id_rt,
+        (long long) id_quad, (long long) id_kd);
+      failures++;
+    }
+
+    meos_initialize_noexit_error_handler();
+    MeosArray *narrow = meos_array_create(sizeof(int));
+    int n_rt = rtree_search(irt, INDEX_OVERLAPS, b, narrow);
+    int n_quad = sptree_search(iquad, INDEX_OVERLAPS, b, narrow);
+    int n_join = rtree_join(irt, irt, INDEX_OVERLAPS, narrow);
+    if (n_rt != -1 || n_quad != -1 || n_join != -1)
+    {
+      printf("index ids: an array of int elements is answered into rather "
+        "than refused, R-tree %d, quad-tree %d, join %d\n", n_rt, n_quad,
+        n_join);
+      failures++;
+    }
+    meos_errno_reset();
+
+    meos_array_destroy(res); meos_array_destroy(narrow);
+    rtree_free(irt); sptree_free(iquad); sptree_free(ikd);
+    free(b);
   }
 
   rtree_free(rt);

--- a/meos/test/rtree_join_test.c
+++ b/meos/test/rtree_join_test.c
@@ -181,13 +181,16 @@ test_stbox_join(IndexSearchOp op, const char *opname, int count1, int count2,
       }
 
   /* Answer of the join */
-  MeosArray *result = meos_array_create(sizeof(int64));
+  MeosArray *result = index_result_create();
   int npairs = rtree_join(rtree1, rtree2, op, result);
   int *found = malloc((size_t) (npairs ? npairs : 1) * 2 * sizeof(int));
   for (int k = 0; k < npairs; k++)
   {
-    found[2 * k] = *(int64 *) meos_array_get(result, 2 * k);
-    found[2 * k + 1] = *(int64 *) meos_array_get(result, 2 * k + 1);
+    int64 id1, id2;
+    index_result_id(result, 2 * k, &id1);
+    index_result_id(result, 2 * k + 1, &id2);
+    found[2 * k] = (int) id1;
+    found[2 * k + 1] = (int) id2;
   }
 
   char name[128];
@@ -253,7 +256,7 @@ test_stbox_join(IndexSearchOp op, const char *opname, int count1, int count2,
 static void
 test_degenerate(void)
 {
-  MeosArray *result = meos_array_create(sizeof(int64));
+  MeosArray *result = index_result_create();
 
   /* An index with no box joins to nothing */
   RTree *empty1 = rtree_create_stbox();
@@ -284,9 +287,10 @@ test_degenerate(void)
   rtree_insert(near, nearbox, 7);
   int n = rtree_join(filled, near, INDEX_OVERLAPS, result);
   check("a single overlapping pair is reported once", n == 1);
+  int64 id1, id2;
   check("the reported ids are the inserted ones", n == 1 &&
-    *(int64 *) meos_array_get(result, 0) == 0 &&
-    *(int64 *) meos_array_get(result, 1) == 7);
+    index_result_id(result, 0, &id1) && id1 == 0 &&
+    index_result_id(result, 1, &id2) && id2 == 7);
 
   /* Boxes overlapping in space but not in time are not reported, since an
    * STBox pair must overlap in every dimension the two boxes share */

--- a/meos/test/rtree_load_test.c
+++ b/meos/test/rtree_load_test.c
@@ -99,12 +99,12 @@ cmp_int64(const void *a, const void *b)
 static int64 *
 search_sorted(const RTree *rtree, const STBox *query, int *count)
 {
-  MeosArray *result = meos_array_create(sizeof(int64));
+  MeosArray *result = index_result_create();
   rtree_search(rtree, INDEX_OVERLAPS, query, result);
   *count = meos_array_count(result);
   int64 *ids = malloc(sizeof(int64) * (size_t) (*count ? *count : 1));
   for (int i = 0; i < *count; i++)
-    ids[i] = *(int64 *) meos_array_get(result, i);
+    index_result_id(result, i, &ids[i]);
   qsort(ids, (size_t) *count, sizeof(int64), cmp_int64);
   meos_array_destroy(result);
   return ids;

--- a/meos/test/rtree_mest_test.c
+++ b/meos/test/rtree_mest_test.c
@@ -140,9 +140,9 @@ int main(void)
    * meaningful for the dedup search) */
   Temporal *query = make_wiggly_trip(123456, buf, sizeof(buf));
 
-  MeosArray *single_ids = meos_array_create(sizeof(int64));
-  MeosArray *mest_ids = meos_array_create(sizeof(int64));
-  MeosArray *deg_ids = meos_array_create(sizeof(int64));
+  MeosArray *single_ids = index_result_create();
+  MeosArray *mest_ids = index_result_create();
+  MeosArray *deg_ids = index_result_create();
 
   int single_count = rtree_search_temporal(rtree_single, INDEX_OVERLAPS,
     query, single_ids);
@@ -158,16 +158,22 @@ int main(void)
   int *mest_seen = calloc(NUM_TRIPS, sizeof(int));
   int *deg_seen = calloc(NUM_TRIPS, sizeof(int));
   for (int i = 0; i < single_count; i++)
-    in_single[*(int64 *) meos_array_get(single_ids, i)] = true;
+  {
+    int64 id;
+    index_result_id(single_ids, i, &id);
+    in_single[id] = true;
+  }
   for (int i = 0; i < mest_count; i++)
   {
-    int64 id = *(int64 *) meos_array_get(mest_ids, i);
+    int64 id;
+    index_result_id(mest_ids, i, &id);
     in_mest[id] = true;
     mest_seen[id]++;
   }
   for (int i = 0; i < deg_count; i++)
   {
-    int64 id = *(int64 *) meos_array_get(deg_ids, i);
+    int64 id;
+    index_result_id(deg_ids, i, &id);
     in_deg[id] = true;
     deg_seen[id]++;
   }

--- a/meos/test/rtree_span_test.c
+++ b/meos/test/rtree_span_test.c
@@ -88,12 +88,16 @@ test_intspan_rtree(void)
   int qlo = random_int(-10000, 10000);
   Span *query = intspan_make(qlo, qlo + 500, true, false);
 
-  MeosArray *result = meos_array_create(sizeof(int64));
+  MeosArray *result = index_result_create();
   int count = rtree_search(rtree, INDEX_OVERLAPS, query, result);
 
   bool *in_index = calloc(NUM_SPANS, sizeof(bool));
   for (int i = 0; i < count; i++)
-    in_index[*(int64 *) meos_array_get(result, i)] = true;
+  {
+    int64 id;
+    index_result_id(result, i, &id);
+    in_index[id] = true;
+  }
 
   printf("Integer span RTree (%d random spans):\n", NUM_SPANS);
 
@@ -134,12 +138,16 @@ test_floatspan_rtree(void)
   double qlo = random_int(-10000, 10000) / 10.0;
   Span *query = floatspan_make(qlo, qlo + 50.0, true, false);
 
-  MeosArray *result = meos_array_create(sizeof(int64));
+  MeosArray *result = index_result_create();
   int count = rtree_search(rtree, INDEX_OVERLAPS, query, result);
 
   bool *in_index = calloc(NUM_SPANS, sizeof(bool));
   for (int i = 0; i < count; i++)
-    in_index[*(int64 *) meos_array_get(result, i)] = true;
+  {
+    int64 id;
+    index_result_id(result, i, &id);
+    in_index[id] = true;
+  }
 
   printf("Float span RTree (%d random spans):\n", NUM_SPANS);
 
@@ -184,7 +192,7 @@ test_id_width(void)
   }
 
   Span *query = intspan_make(-100, 1000, true, false);
-  MeosArray *result = meos_array_create(sizeof(int64));
+  MeosArray *result = index_result_create();
   int count = rtree_search(rtree, INDEX_OVERLAPS, query, result);
 
   printf("Identifier width (%d spans, ids above 2^31):\n", nids);
@@ -197,7 +205,8 @@ test_id_width(void)
   {
     for (int i = 0; i < count; i++)
     {
-      int64 got = *(int64 *) meos_array_get(result, i);
+      int64 got;
+      index_result_id(result, i, &got);
       bool found = false;
       for (int k = 0; k < nids; k++)
         if (ids[k] == got) found = true;

--- a/meos/test/sptree_join_test.c
+++ b/meos/test/sptree_join_test.c
@@ -239,13 +239,16 @@ test_stbox_join(IndexSearchOp op, const char *opname, SPTreeKind kind1,
       }
 
   /* Answer of the join */
-  MeosArray *result = meos_array_create(sizeof(int64));
+  MeosArray *result = index_result_create();
   int npairs = sptree_join(sptree1, sptree2, op, result);
   int *found = malloc((size_t) (npairs ? npairs : 1) * 2 * sizeof(int));
   for (int k = 0; k < npairs; k++)
   {
-    found[2 * k] = (int) *(int64 *) meos_array_get(result, 2 * k);
-    found[2 * k + 1] = (int) *(int64 *) meos_array_get(result, 2 * k + 1);
+    int64 id1, id2;
+    index_result_id(result, 2 * k, &id1);
+    index_result_id(result, 2 * k + 1, &id2);
+    found[2 * k] = (int) id1;
+    found[2 * k + 1] = (int) id2;
   }
 
   char name[128];
@@ -312,7 +315,7 @@ test_stbox_join(IndexSearchOp op, const char *opname, SPTreeKind kind1,
 static void
 test_degenerate(void)
 {
-  MeosArray *result = meos_array_create(sizeof(int64));
+  MeosArray *result = index_result_create();
 
   /* An index with no box joins to nothing */
   SPTree *empty1 = sptree_create_stbox(SPTREE_QUADTREE);
@@ -343,9 +346,10 @@ test_degenerate(void)
   sptree_insert(near, nearbox, 7);
   int n = sptree_join(filled, near, INDEX_OVERLAPS, result);
   check("a single overlapping pair is reported once", n == 1);
+  int64 id1, id2;
   check("the reported ids are the inserted ones", n == 1 &&
-    *(int64 *) meos_array_get(result, 0) == 0 &&
-    *(int64 *) meos_array_get(result, 1) == 7);
+    index_result_id(result, 0, &id1) && id1 == 0 &&
+    index_result_id(result, 1, &id2) && id2 == 7);
 
   /* Boxes overlapping in space but not in time are not reported, since an
    * STBox pair must overlap in every dimension the two boxes share */
@@ -370,7 +374,7 @@ static void
 test_refused(void)
 {
   meos_initialize_noexit_error_handler();
-  MeosArray *result = meos_array_create(sizeof(int64));
+  MeosArray *result = index_result_create();
 
   SPTree *stboxtree = sptree_create_stbox(SPTREE_QUADTREE);
   SPTree *other = sptree_create_stbox(SPTREE_KDTREE);

--- a/meos/test/sptree_load_test.c
+++ b/meos/test/sptree_load_test.c
@@ -143,12 +143,12 @@ make_tbox(int vlo, int vspan)
 static int64 *
 search_sorted(const SPTree *sptree, const TBox *query, int *count)
 {
-  MeosArray *result = meos_array_create(sizeof(int64));
+  MeosArray *result = index_result_create();
   sptree_search(sptree, INDEX_OVERLAPS, query, result);
   *count = meos_array_count(result);
   int64 *ids = malloc(sizeof(int64) * (size_t) (*count ? *count : 1));
   for (int i = 0; i < *count; i++)
-    ids[i] = *(int64 *) meos_array_get(result, i);
+    index_result_id(result, i, &ids[i]);
   qsort(ids, (size_t) *count, sizeof(int64), cmp_int64);
   meos_array_destroy(result);
   return ids;
@@ -401,12 +401,12 @@ test_stbox(SPTreeKind kind, const char *kindname)
       x, y, x + 60, y + 60);
     STBox *query = stbox_in(buf);
 
-    MeosArray *result = meos_array_create(sizeof(int64));
+    MeosArray *result = index_result_create();
     sptree_search(loaded, INDEX_OVERLAPS, query, result);
     int ngot = meos_array_count(result);
     int64 *got = malloc(sizeof(int64) * (size_t) (ngot ? ngot : 1));
     for (int i = 0; i < ngot; i++)
-      got[i] = *(int64 *) meos_array_get(result, i);
+      index_result_id(result, i, &got[i]);
     qsort(got, (size_t) ngot, sizeof(int64), cmp_int64);
     meos_array_destroy(result);
 

--- a/meos/test/sptree_test.c
+++ b/meos/test/sptree_test.c
@@ -103,11 +103,15 @@ static void
 compare(const char *label, const SPTree *sptree, IndexSearchOp op,
   const void *query, const bool *truth)
 {
-  MeosArray *result = meos_array_create(sizeof(int64));
+  MeosArray *result = index_result_create();
   int count = sptree_search(sptree, op, query, result);
   bool *in_index = calloc(NUM_BOXES, sizeof(bool));
   for (int i = 0; i < count; i++)
-    in_index[*(int64 *) meos_array_get(result, i)] = true;
+  {
+    int64 id;
+    index_result_id(result, i, &id);
+    in_index[id] = true;
+  }
 
   int missed = 0, extra = 0;
   for (int i = 0; i < NUM_BOXES; i++)
@@ -412,9 +416,9 @@ test_mest(void)
   }
   Temporal *query = make_wiggly_tfloat(123456, buf, sizeof(buf));
 
-  MeosArray *single_ids = meos_array_create(sizeof(int64));
-  MeosArray *mest_ids = meos_array_create(sizeof(int64));
-  MeosArray *deg_ids = meos_array_create(sizeof(int64));
+  MeosArray *single_ids = index_result_create();
+  MeosArray *mest_ids = index_result_create();
+  MeosArray *deg_ids = index_result_create();
   int single_count = sptree_search_temporal(single, INDEX_OVERLAPS, query,
     single_ids);
   int mest_count = sptree_search_temporal_dedup(mest, INDEX_OVERLAPS, query,
@@ -428,16 +432,22 @@ test_mest(void)
   int *mest_seen = calloc(NUM_TRIPS, sizeof(int));
   int *deg_seen = calloc(NUM_TRIPS, sizeof(int));
   for (int i = 0; i < single_count; i++)
-    in_single[*(int64 *) meos_array_get(single_ids, i)] = true;
+  {
+    int64 id;
+    index_result_id(single_ids, i, &id);
+    in_single[id] = true;
+  }
   for (int i = 0; i < mest_count; i++)
   {
-    int64 id = *(int64 *) meos_array_get(mest_ids, i);
+    int64 id;
+    index_result_id(mest_ids, i, &id);
     in_mest[id] = true;
     mest_seen[id]++;
   }
   for (int i = 0; i < deg_count; i++)
   {
-    int64 id = *(int64 *) meos_array_get(deg_ids, i);
+    int64 id;
+    index_result_id(deg_ids, i, &id);
     in_deg[id] = true;
     deg_seen[id]++;
   }
@@ -547,9 +557,9 @@ test_stbox_mest(void)
   }
   Temporal *query = make_wiggly_trip(123456, buf, sizeof(buf));
 
-  MeosArray *single_ids = meos_array_create(sizeof(int64));
-  MeosArray *mest_ids = meos_array_create(sizeof(int64));
-  MeosArray *deg_ids = meos_array_create(sizeof(int64));
+  MeosArray *single_ids = index_result_create();
+  MeosArray *mest_ids = index_result_create();
+  MeosArray *deg_ids = index_result_create();
   int single_count = sptree_search_temporal(single, INDEX_OVERLAPS, query,
     single_ids);
   int mest_count = sptree_search_temporal_dedup(mest, INDEX_OVERLAPS, query,
@@ -563,16 +573,22 @@ test_stbox_mest(void)
   int *mest_seen = calloc(NUM_TRIPS, sizeof(int));
   int *deg_seen = calloc(NUM_TRIPS, sizeof(int));
   for (int i = 0; i < single_count; i++)
-    in_single[*(int64 *) meos_array_get(single_ids, i)] = true;
+  {
+    int64 id;
+    index_result_id(single_ids, i, &id);
+    in_single[id] = true;
+  }
   for (int i = 0; i < mest_count; i++)
   {
-    int64 id = *(int64 *) meos_array_get(mest_ids, i);
+    int64 id;
+    index_result_id(mest_ids, i, &id);
     in_mest[id] = true;
     mest_seen[id]++;
   }
   for (int i = 0; i < deg_count; i++)
   {
-    int64 id = *(int64 *) meos_array_get(deg_ids, i);
+    int64 id;
+    index_result_id(deg_ids, i, &id);
     in_deg[id] = true;
     deg_seen[id]++;
   }
@@ -930,11 +946,15 @@ static void
 selective(const char *label, const SPTree *sptree, const void *query,
   const bool *truth, int ntruth)
 {
-  MeosArray *result = meos_array_create(sizeof(int64));
+  MeosArray *result = index_result_create();
   int count = sptree_search(sptree, INDEX_OVERLAPS, query, result);
   bool *in_index = calloc(SEL_BOXES, sizeof(bool));
   for (int i = 0; i < count; i++)
-    in_index[*(int64 *) meos_array_get(result, i)] = true;
+  {
+    int64 id;
+    index_result_id(result, i, &id);
+    in_index[id] = true;
+  }
   int missed = 0;
   for (int i = 0; i < SEL_BOXES; i++)
     if (truth[i] && ! in_index[i])
@@ -1053,7 +1073,7 @@ test_reported_size(SPTreeKind kind, const char *kindname)
 
   /* A tree holding nothing */
   SPTree *none = sptree_create_stbox(kind);
-  MeosArray *result = meos_array_create(sizeof(int64));
+  MeosArray *result = index_result_create();
   STBox *query = random_stbox(200, 50);
   int count = sptree_search(none, INDEX_OVERLAPS, query, result);
   snprintf(name, sizeof(name), "%s empty answers 0, not the error sentinel",


### PR DESCRIPTION
A search or a join of an RTree or an SPTree copies each id it answers into
the caller's result array, and the id is 64 bits wide. The copy is
`memcpy(slot, &id, array->elem_size)`, so the width of an id in the array is
the width the caller created the array with. Every caller stated that width
itself, with `meos_array_create(sizeof(int64))`, and read each id back
through a raw `*(int64 *) meos_array_get(array, n)` cast: 55 arrays and 58
reads across the library, its tests and its examples. Nothing checked that
the two agree. An array of `int` elements keeps the low four bytes of each id
on a little-endian machine and the high four on a big-endian one, and the
search reports success either way.

This adds the two functions that make the width the index's to state:

- `MeosArray *index_result_create(void)` makes the array a search or a join
  fills;
- `bool index_result_id(const MeosArray *result, int n, int64 *id)` reads the
  id at position `n`, 0-based, validating the array and the position. A join
  answers two ids per pair, read at `2 * k` and `2 * k + 1`.

Both belong to the family the RTree and the SPTree share, which already
carries the `IndexSearchOp` operations and `ensure_index_join_op`, so they
take the `index_` prefix and name neither tree. `index_result_id` has the
shape of `bigintset_value_n`: an `int64` out-parameter and a `bool` answer.
Inside MEOS, the loops over candidates read through `INDEX_RESULT_ID_N`, the
internal counterpart, which indexes the array directly rather than calling
`meos_array_get` once per id. The search, the join and the deduplicating search
of both indexes refuse an array that cannot hold the ids, through
`ensure_index_result`.

Every site moves onto the helpers: 19 arrays and 28 reads in `meos/src`, 34
and 26 in `meos/test`, 2 and 4 in `meos/examples`. The documentation of the
eight entry points names `index_result_create` as the array each fills,
where several described a `MeosArray of int`.

The witness is a section of `index_position_test`. It inserts the id
4294967301 into an R-tree, a quad-tree and a k-d tree, reads it back through
`index_result_create` and `index_result_id`, and searches each index into an
array of `int` elements. On master that search answers 1 on the R-tree and on
the quad-tree, the id reads back as 5, and no error is raised. On the branch
the three ids read back whole and every index refuses the narrow array.

Why this is safe for a caller that already follows the documented idiom: an
array made by `meos_array_create(sizeof(int64))` has the element width
`ensure_index_result` asks for, so it is accepted exactly as before. Only an
array of another width is refused, and that array answered wrong ids.

Measured: ctest 337 of 337 on PostgreSQL 18; the 59 `meos/test` invocations
of meos.yml, `threaded_test` under ThreadSanitizer, the Windows MSYS2 build and
the 7 generated smoke suites under valgrind all clean; cppcheck 152 findings on
both arms, 0 new; the coverage instruments, 45 on each arm, move one line, the
clock.

Performance: the searches add two comparisons per call, and each id read in
the library's own loops drops a function call. Relate over five large
natural-area pairs, the pairs whose edge counts put the relate engine on its
index, native / GEOS as MEOS calls it in one process, arms alternated over
four rounds: master 67.5, 54.3, 66.4, 65.8; branch 60.9, 61.1, 65.2, 53.1.
The instruction count of one round under callgrind, which no load moves:
native 33,617.2M on master and 33,515.5M on the branch (-0.30%), GEOS as MEOS
calls it 404.3M in both, so native / GEOS goes from 83.14 to 82.89.

