### PR TITLE
Decide which buffer pieces to keep from the edges an R-tree finds near them

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -4962,6 +4962,76 @@ buffer_point_edges_distance(double x, double y, const MeosArray *edges)
 }
 
 /**
+ * @brief Return an R-tree of the boxes of the edges of a geometry, by their
+ * position in the array
+ * @details A box is widened by the rounding of the coordinates it is read
+ * from, so the index admits every edge the distance of
+ * #buffer_point_edge_distance reaches within a box query: an index may admit
+ * more candidates than it needs, never fewer
+ */
+static RTree *
+buffer_edges_index(const MeosArray *edges)
+{
+  RTree *index = rtree_create_stbox();
+  for (uint32_t i = 0; i < edges->count; i++)
+  {
+    const Edge *e = (const Edge *) meos_array_get(edges, i);
+    if (! e || e->etype == EDGE_POINT)
+      continue;
+    double pad = e->tol + 16.0 * DBL_EPSILON * (fabs(e->xmin) +
+      fabs(e->xmax) + fabs(e->ymin) + fabs(e->ymax));
+    if (e->etype == EDGE_POLYARC || e->etype == EDGE_LINEARC)
+      pad += 16.0 * DBL_EPSILON * e->radius;
+    STBox box;
+    stbox_set(true, false, false, 0, e->xmin - pad, e->xmax + pad,
+      e->ymin - pad, e->ymax + pad, 0, 0, NULL, &box);
+    rtree_insert(index, &box, i);
+  }
+  return index;
+}
+
+/**
+ * @brief Return true when an edge of a geometry lies nearer a point than a
+ * distance
+ * @details The same answer as comparing #buffer_point_edges_distance with the
+ * distance, read from the edges whose box reaches within the distance of the
+ * point, and settled at the first edge found nearer
+ * @param[in] index R-tree of #buffer_edges_index
+ * @param[out] found Room for the positions the index answers
+ */
+static bool
+buffer_point_edges_nearer(double x, double y, const MeosArray *edges,
+  const RTree *index, double limit, MeosArray *found)
+{
+  /* The distance over no edge is DBL_MAX and over any edge at least 0, so
+   * these two answers need no edge: every distance is below a limit beyond
+   * DBL_MAX or not a number, and none is below a limit of 0 */
+  if (! (limit <= DBL_MAX))
+    return true;
+  if (limit <= 0.0)
+    return false;
+  /* A distance computed below the limit may belong to a point that lies
+   * beyond it by the rounding of that distance, which grows with the limit
+   * and with the magnitude of the point, so the query reaches that far */
+  double reach = limit + 16.0 * DBL_EPSILON * (limit + fabs(x) + fabs(y));
+  STBox query;
+  stbox_set(true, false, false, 0, nextafter(x - reach, -INFINITY),
+    nextafter(x + reach, INFINITY), nextafter(y - reach, -INFINITY),
+    nextafter(y + reach, INFINITY), 0, 0, NULL, &query);
+  meos_array_reset(found);
+  int nc = rtree_search(index, INDEX_OVERLAPS, &query, found);
+  for (int c = 0; c < nc; c++)
+  {
+    const Edge *e = (const Edge *) meos_array_get(edges,
+      (int) INDEX_RESULT_ID_N(found, c));
+    if (e && e->etype != EDGE_POINT &&
+        buffer_point_edge_distance(x, y, e) < limit)
+      return true;
+  }
+  return false;
+}
+
+/**
  * @brief Return the boundary of the buffer of a geometry, given a ring of
  * offsets that may run into itself
  * @details Every piece of the ring is split where it meets any other piece of
@@ -5041,6 +5111,8 @@ buffer_ring_resolve(const LWGEOM *raw, const MeosArray *edges, double radius,
    * of the question */
   double tol = Max(MEOS_GEOM_TOLERANCE, radius * 1.0e-9);
   MeosArray *keep = meos_array_create(sizeof(BufferPiece));
+  RTree *index = buffer_edges_index(edges);
+  MeosArray *found = index_result_create();
   for (int i = 0; i < meos_array_count(split); i++)
   {
     BufferPiece *piece = (BufferPiece *) meos_array_get(split, (uint32_t) i);
@@ -5055,9 +5127,12 @@ buffer_ring_resolve(const LWGEOM *raw, const MeosArray *edges, double radius,
      * bound of `radius * 1e-9` calibrated to a radius of 1, and the piece is
      * dropped: the ring it belongs to then reaches a point nothing continues */
     double mid_tol = Max(tol, coordinate_tolerance(mid.x, mid.y));
-    if (buffer_point_edges_distance(mid.x, mid.y, edges) >= radius - mid_tol)
+    if (! buffer_point_edges_nearer(mid.x, mid.y, edges, index,
+        radius - mid_tol, found))
       meos_array_add(keep, piece);
   }
+  meos_array_destroy(found);
+  rtree_free(index);
 
   LWGEOM *result = (meos_array_count(keep) > 0) ?
     buffer_make_surfaces_from_pieces(keep, srid) : NULL;


### PR DESCRIPTION
buffer_ring_resolve keeps a piece of the offset ring when the geometry comes
no nearer to its middle than the buffer distance, and it read that distance
as the minimum over EVERY edge of the geometry, one hypot at least per edge
and per piece. A geometry of n edges splits into pieces in proportion to n,
so the resolver is quadratic, and on the natural-area polygons it is where
the native buffer spends most of its time against GEOS.

The resolver builds an R-tree of the edge boxes once per ring, reads the
edges whose box reaches within the distance of the middle, and settles a
piece at the first edge found nearer. The answer is the one the minimum over
every edge gives, for every piece: a piece is dropped exactly when some edge
lies nearer than the distance, and the index hands over every such edge. An
edge box is widened by the rounding of the coordinates and of the arc radius
it is read from, and the query by the rounding the distance carries, which
grows with the distance and with the magnitude of the point, so an edge a
computed distance places inside the limit is never outside the query. A limit
of 0 or less keeps the piece and a limit beyond DBL_MAX or not a number drops
it, as the minimum over no edge, DBL_MAX, decides.

The witness is the answer itself, bit for bit: every buffer the resolver
builds on the natural-area polygons, the joint sweep, the curved shapes, the
arcs at scale 2^-8, the polygons of 100 to 400 KB and the unit shapes at
radii 10^3 and 10^6 is the hex EWKB master builds, 938 answers with the same
declines.

Measured: ctest 337 of 337 on PostgreSQL 18, the Windows MSYS2 build,
cppcheck with 0 new findings, and the coverage instruments, 45 on each arm,
moving one line, the clock. The buffer of the natural-area polygons
common to both arms, native / GEOS as MEOS calls it in one process, arms
alternated over four rounds:

  r = 1    master 30.5, 28.7, 26.2, 30.4   here 17.8, 18.8, 17.9, 19.5
  r = 50   master 47.4, 49.9, 53.6, 37.0   here 28.0, 24.5, 19.7, 22.7
  r = 500  master 22.7, 21.7, 21.1, 21.9   here  9.6,  9.8,  9.9,  9.5

One round at r = 50 under callgrind, which no load moves: native 61,995.3M
instructions on master and 27,601.5M here, 2.25 times fewer, GEOS 718.9M on
both, so native / GEOS goes from 86.2 to 38.4. On the twelve polygons of
100 to 400 KB the wall time falls 1.21 times at r = 1 and 1.23 times at
r = 50: a DWARF profile of those polygons puts 13% of the buffer in this
resolver and 79% in buffer_union_components, whose containment and
boundary-meeting tests walk every edge pair of two components.

Why: the index answers the same question over a subset that provably holds
every edge able to change the answer, so the change moves cost and never an
answer.

