### PR TITLE
Give the examples of each tessellation entry one shape

### DIFF
--- a/doc/es/temporal_cell_index.xml
+++ b/doc/es/temporal_cell_index.xml
@@ -1104,7 +1104,7 @@ SELECT ST_NPoints(getValue(cellToBoundary(ts2cell '47c3c@2001-01-01'))::geometry
 	</sect1>
 	<sect1 xml:id="tcell_bbox_ops">
 		<title>Operaciones de cuadro delimitador</title>
-		<para>Los siguientes operadores comparan el <emphasis>cuadro delimitador</emphasis> espaciotemporal de las celdas temporales en lugar de la contención en la jerarquía de celdas. <varname>tcell</varname> es un tipo temporal espacial: su cuadro delimitador es un <varname>stbox</varname> que combina la extensión espacial geodésica de las fronteras de las celdas (su envolvente de longitud/latitud en el SRID 4326) con el período de tiempo <varname>tstzspan</varname> de la trayectoria. Los operadores de más abajo comparan ese cuadro a lo largo de los ejes espaciales y/o del eje temporal. Véase la sección de indexación para las clases de operadores que hacen que estos operadores puedan usar índices.</para>
+		<para>Los siguientes operadores comparan el <emphasis>cuadro delimitador</emphasis> espaciotemporal de las celdas temporales en lugar de la contención en la jerarquía de celdas. <varname>tcell</varname> es un tipo temporal espacial: su cuadro delimitador es un <varname>stbox</varname> que combina la extensión espacial de las fronteras de las celdas (su envolvente de longitud/latitud en el SRID 4326), geodésica para una celda H3 o S2 y plana para una celda QUADBIN, con el período de tiempo <varname>tstzspan</varname> de la trayectoria. Los operadores de más abajo comparan ese cuadro a lo largo de los ejes espaciales y/o del eje temporal. Véase la sección de indexación para las clases de operadores que hacen que estos operadores puedan usar índices.</para>
 
 		<note>
 			<para>El operador <varname>@&gt;</varname> comprueba la contención del cuadro delimitador espaciotemporal (la extensión espacial y el tiempo conjuntamente), <emphasis>no</emphasis> la contención en la jerarquía de celdas. Para comprobar si una celda es el ancestro de otra en una resolución dada, use <link linkend="tcell_cell_to_parent"><varname>cellToParent</varname></link>.</para>
@@ -1119,7 +1119,7 @@ SELECT ST_NPoints(getValue(cellToBoundary(ts2cell '47c3c@2001-01-01'))::geometry
 stbox(tcell) &#8594; stbox
 expandSpace(tcell,float) &#8594; stbox
 </programlisting>
-				<para>El cuadro es la envolvente geodésica de las fronteras de las celdas junto con el período de tiempo de la trayectoria, de modo que es la clave que almacenan ambas clases de operadores de índice de la sección de indexación.</para>
+				<para>El cuadro es la envolvente de las fronteras de las celdas, geodésica para una celda H3 o S2 y plana para una celda QUADBIN, junto con el período de tiempo de la trayectoria, de modo que es la clave que almacenan ambas clases de operadores de índice de la sección de indexación.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(stbox(th3index '871fa44a8ffffff@2001-01-01'), 6);
 /* SRID=4326;GEODSTBOX XT(((4.280027,50.79295),(4.314775,50.815648)),
@@ -1575,7 +1575,7 @@ SELECT mergeAgg(temp) FROM (VALUES (ts2cell '47c3c@2001-01-01')) AS t(temp);
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE INDEX Trips_Cells_SPGist_Idx ON Trips USING SPGist(Cells);
 </programlisting>
-		<para>Los índices GiST y SP-GiST almacenan el cuadro delimitador para las celdas temporales, que es un <varname>stbox</varname>, como todos los tipos espaciotemporales: la extensión geodésica de las fronteras de las celdas junto con el período de tiempo.</para>
+		<para>Los índices GiST y SP-GiST almacenan el cuadro delimitador para las celdas temporales, que es un <varname>stbox</varname>, como todos los tipos espaciotemporales: la extensión de las fronteras de las celdas, geodésica para las celdas H3 y S2 y plana para las celdas QUADBIN, junto con el período de tiempo.</para>
 
 		<para>Cada clase de operadores lleva el nombre del tipo temporal que indexa, de modo que una columna <varname>th3index</varname> toma <varname>th3index_rtree_ops</varname> para GiST y <varname>th3index_quadtree_ops</varname> o <varname>th3index_kdtree_ops</varname> para SP-GiST, y los nombres de <varname>tquadbin</varname> y <varname>ts2cell</varname> igualmente. La clase de árbol cuaternario es la predeterminada de SP-GiST y la clase de árbol k-d se nombra explícitamente. También se definen una clase de operadores B-tree y una hash, que ordenan y aplican hash por el valor temporal subyacente.</para>
 

--- a/doc/es/temporal_cell_index.xml
+++ b/doc/es/temporal_cell_index.xml
@@ -95,8 +95,20 @@ text(tcell) → text
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '831c02fffffffff@2001-01-01';
 -- 831c02fffffffff@2001-01-01
+SELECT th3index '[831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02]';
+-- [831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02]
+SELECT th3index '{[831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02]}';
+-- {[831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02]}
+SELECT tquadbin '48a6227affffffff@2001-01-01';
+-- 48a6227affffffff@2001-01-01
 SELECT tquadbin '[48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-02]';
 -- [48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-02]
+SELECT tquadbin '{[48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-02]}';
+-- {[48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-02]}
+SELECT ts2cell '47c3c@2001-01-01';
+-- 47c3c@2001-01-01
+SELECT ts2cell '[47c3c@2001-01-01, 47c4@2001-01-02]';
+-- [47c3c@2001-01-01, 47c4@2001-01-02]
 SELECT ts2cell '{[47c3c@2001-01-01, 47c4@2001-01-02]}';
 -- {[47c3c@2001-01-01, 47c4@2001-01-02]}
 </programlisting>
@@ -450,9 +462,8 @@ getValues(tcell) → cellset
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getValues(th3index '831c02fffffffff@2001-01-01');
 -- {"831c02fffffffff"}
-SELECT getValues(th3index '[831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02,
-    880326b885fffff@2001-01-03]');
--- {"831c00fffffffff", "831c02fffffffff", "880326b885fffff"}
+SELECT getValues(th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02}');
+-- {"831c00fffffffff", "831c02fffffffff"}
 SELECT getValues(tquadbin '48a6227affffffff@2001-01-01');
 -- {"48a6227affffffff"}
 SELECT getValues(tquadbin '{48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-02}');
@@ -477,7 +488,8 @@ SELECT valueAtTimestamp(th3index
 SELECT valueAtTimestamp(tquadbin
   '[48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-05]', '2001-01-03');
 -- 48a6227affffffff
-SELECT valueAtTimestamp(ts2cell '47c3c@2001-01-01', timestamptz '2001-01-01');
+SELECT valueAtTimestamp(ts2cell
+  '[47c3c@2001-01-01, 47c4@2001-01-05]', '2001-01-03');
 -- 47c3c
 </programlisting>
 			</listitem>
@@ -702,9 +714,21 @@ appendSequence(tcell,tcellSeq) &#8594; tcell
 SELECT asText(appendInstant(th3index '831c02fffffffff@2001-01-01',
   th3index '831c00fffffffff@2001-01-02'));
 -- [831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02]
+SELECT asText(appendSequence(th3index '[831c02fffffffff@2001-01-01]',
+  th3index '[831c00fffffffff@2001-01-02]'));
+-- {[831c02fffffffff@2001-01-01], [831c00fffffffff@2001-01-02]}
+SELECT asText(appendInstant(tquadbin '48a6227affffffff@2001-01-01',
+  tquadbin '485623ffffffffff@2001-01-02'));
+-- [48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-02]
 SELECT asText(appendSequence(tquadbin '[48a6227affffffff@2001-01-01]',
   tquadbin '[485623ffffffffff@2001-01-02]'));
 -- {[48a6227affffffff@2001-01-01], [485623ffffffffff@2001-01-02]}
+SELECT asText(appendInstant(ts2cell '47c3c@2001-01-01',
+  ts2cell '47c4@2001-01-02'));
+-- [47c3c@2001-01-01, 47c4@2001-01-02]
+SELECT asText(appendSequence(ts2cell '[47c3c@2001-01-01]',
+  ts2cell '[47c4@2001-01-02]'));
+-- {[47c3c@2001-01-01], [47c4@2001-01-02]}
 </programlisting>
 			</listitem>
 			<listitem xml:id="tcell_merge">
@@ -715,12 +739,24 @@ merge(tcell,tcell) &#8594; tcell
 merge(tcell[]) &#8594; tcell
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT asText(merge(ts2cell '[47c3c@2001-01-01, 47c3c@2001-01-03]',
-  ts2cell '[47c3c@2001-01-03, 47c4@2001-01-05]'));
--- [47c3c@2001-01-01, 47c4@2001-01-05]
+SELECT asText(merge(th3index '[831c02fffffffff@2001-01-01, 831c02fffffffff@2001-01-03]',
+  th3index '[831c02fffffffff@2001-01-03, 831c00fffffffff@2001-01-05]'));
+-- [831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-05]
 SELECT asText(merge(ARRAY[th3index '831c02fffffffff@2001-01-01',
   th3index '831c00fffffffff@2001-01-03']));
 -- {831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-03}
+SELECT asText(merge(tquadbin '[48a6227affffffff@2001-01-01, 48a6227affffffff@2001-01-03]',
+  tquadbin '[48a6227affffffff@2001-01-03, 485623ffffffffff@2001-01-05]'));
+-- [48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-05]
+SELECT asText(merge(ARRAY[tquadbin '48a6227affffffff@2001-01-01',
+  tquadbin '485623ffffffffff@2001-01-03']));
+-- {48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-03}
+SELECT asText(merge(ts2cell '[47c3c@2001-01-01, 47c3c@2001-01-03]',
+  ts2cell '[47c3c@2001-01-03, 47c4@2001-01-05]'));
+-- [47c3c@2001-01-01, 47c4@2001-01-05]
+SELECT asText(merge(ARRAY[ts2cell '47c3c@2001-01-01',
+  ts2cell '47c4@2001-01-03']));
+-- {47c3c@2001-01-01, 47c4@2001-01-03}
 </programlisting>
 			</listitem>
 			<listitem xml:id="tcell_set_interp">
@@ -736,8 +772,9 @@ SELECT setInterp(th3index '{871fa4418ffffff@2001-01-01,
 SELECT setInterp(tquadbin '{48a6227affffffff@2001-01-01,
   485623ffffffffff@2001-01-02}', 'step');
 -- {[48a6227affffffff@2001-01-01], [485623ffffffffff@2001-01-02]}
-SELECT setInterp(ts2cell '{47c3c@2001-01-01}', 'step');
--- [47c3c@2001-01-01]
+SELECT setInterp(ts2cell '{47c3c@2001-01-01,
+  47c4@2001-01-02}', 'step');
+-- {[47c3c@2001-01-01], [47c4@2001-01-02]}
 </programlisting>
 			</listitem>
 		</itemizedlist>
@@ -763,8 +800,10 @@ SELECT insert(tquadbin '[48a6227affffffff@2001-01-01,
   485623ffffffffff@2001-01-04]');
 /* [48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-03,
    485623ffffffffff@2001-01-04] */
-SELECT insert(ts2cell '47c3c@2001-01-01', ts2cell '47c4@2001-01-02');
--- {47c3c@2001-01-01, 47c4@2001-01-02}
+SELECT insert(ts2cell '[47c3c@2001-01-01,
+  47c3c@2001-01-02]', ts2cell '[47c4@2001-01-03,
+  47c4@2001-01-04]');
+-- [47c3c@2001-01-01, 47c4@2001-01-03, 47c4@2001-01-04]
 </programlisting>
 			</listitem>
 
@@ -781,8 +820,9 @@ SELECT deleteTime(th3index '[871fa4418ffffff@2001-01-01,
 SELECT deleteTime(tquadbin '[48a6227affffffff@2001-01-01,
   48a6227affffffff@2001-01-04]', tstzspan '[2001-01-02, 2001-01-03]');
 -- [48a6227affffffff@2001-01-01, 48a6227affffffff@2001-01-04]
-SELECT deleteTime(ts2cell '47c3c@2001-01-01', tstzspan '[2001-01-02, 2001-01-03]');
--- 47c3c@2001-01-01
+SELECT deleteTime(ts2cell '[47c3c@2001-01-01,
+  47c3c@2001-01-04]', tstzspan '[2001-01-02, 2001-01-03]');
+-- [47c3c@2001-01-01, 47c3c@2001-01-04]
 </programlisting>
 			</listitem>
 		</itemizedlist>
@@ -809,8 +849,9 @@ SELECT atValue(th3index '{871fa4418ffffff@2001-01-01,
 SELECT atValue(tquadbin '{48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-02}',
   quadbin '48a6227affffffff');
 -- {48a6227affffffff@2001-01-01}
-SELECT atValue(ts2cell '47c3c@2001-01-01', s2cell '47c3c');
--- 47c3c@2001-01-01
+SELECT atValue(ts2cell '{47c3c@2001-01-01, 47c4@2001-01-02}',
+  s2cell '47c3c');
+-- {47c3c@2001-01-01}
 </programlisting>
 			</listitem>
 
@@ -829,8 +870,9 @@ SELECT atTime(th3index '[871fa4418ffffff@2001-01-01,
 SELECT atTime(tquadbin '[48a6227affffffff@2001-01-01, 48a6227affffffff@2001-01-04]',
   tstzspan '[2001-01-02, 2001-01-03]');
 -- [48a6227affffffff@2001-01-02, 48a6227affffffff@2001-01-03]
-SELECT atTime(ts2cell '47c3c@2001-01-01', tstzspan '[2001-01-01, 2001-01-02]');
--- 47c3c@2001-01-01
+SELECT atTime(ts2cell '[47c3c@2001-01-01, 47c3c@2001-01-04]',
+  tstzspan '[2001-01-02, 2001-01-03]');
+-- [47c3c@2001-01-02, 47c3c@2001-01-03]
 </programlisting>
 			</listitem>
 		</itemizedlist>
@@ -906,8 +948,12 @@ SELECT getResolution(h3index '831c02fffffffff');
 -- 3
 SELECT getResolution(th3index '831c02fffffffff@2001-01-01');
 -- 3@2001-01-01
+SELECT getResolution(quadbin '48a6227affffffff');
+-- 10
 SELECT getResolution(tquadbin '48a6227affffffff@2001-01-01');
 -- 10@2001-01-01
+SELECT getResolution(s2cell '47c3c');
+-- 7
 SELECT getResolution(ts2cell '47c3c@2001-01-01');
 -- 7@2001-01-01
 </programlisting>
@@ -924,14 +970,18 @@ isValidCell(tcell) → tbool
 				<para>Un valor es una celda válida cuando su patrón de bits denota algo que su cuadrícula indexa: para QUADBIN, coordenadas de tesela dentro de los límites de la resolución que declara el identificador; para H3, una celda base y una secuencia de dígitos que lleva el icosaedro; para S2, una cara y una posición de Hilbert en un nivel entre 0 y 30.</para>
 				<para>Solo a H3 se le puede plantear la pregunta sobre un valor que responde <varname>false</varname>: su función de entrada admite cualquier patrón de bits y deja el veredicto a esta función, mientras que las funciones de entrada de QUADBIN y de S2 rechazan un patrón que no indexa nada, de modo que <varname>tquadbin '0'</varname> y <varname>ts2cell '0'</varname> provocan un error antes de que se haga la llamada.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT isValidCell(quadbin '48a6227affffffff');
+SELECT isValidCell(h3index '831c02fffffffff');
 -- t
 SELECT isValidCell(th3index '831c02fffffffff@2001-01-01');
 -- t@2001-01-01
 SELECT isValidCell(th3index '0@2001-01-01');
 -- f@2001-01-01
+SELECT isValidCell(quadbin '48a6227affffffff');
+-- t
 SELECT isValidCell(tquadbin '48a6227affffffff@2001-01-01');
 -- t@2001-01-01
+SELECT isValidCell(s2cell '47c3c');
+-- t
 SELECT isValidCell(ts2cell '47c3c@2001-01-01');
 -- t@2001-01-01
 </programlisting>
@@ -953,13 +1003,17 @@ cellToParent(tcell) → tcell
 </programlisting>
 				<para>Devolver el ancestro de una celda en la resolución más gruesa dada. La forma estática toma una única <varname>cell</varname>; la forma temporal devuelve el ancestro de cada celda de una trayectoria. La forma sin argumento desciende a la resolución inmediatamente más gruesa.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT cellToParent(h3index '8a2a1072b59ffff', 5);
--- 852a1073fffffff
+SELECT getResolution(cellToParent(h3index '8a2a1072b59ffff', 5));
+-- 5
 SELECT getResolution(cellToParent(th3index '8a2a1072b59ffff@2001-01-01', 5));
 -- 5@2001-01-01
+SELECT getResolution(cellToParent(quadbin '48a6227affffffff', 5));
+-- 5
 SELECT getResolution(cellToParent(tquadbin
   '48a6227affffffff@2001-01-01', 5));
 -- 5@2001-01-01
+SELECT getResolution(cellToParent(s2cell '47c3c', 5));
+-- 5
 SELECT getResolution(cellToParent(ts2cell '47c3c@2001-01-01', 5));
 -- 5@2001-01-01
 </programlisting>
@@ -1006,8 +1060,12 @@ SELECT asText(cellToPoint(th3index '871fa44a8ffffff@2001-01-01'), 6);
 -- POINT(4.297401 50.8043)@2001-01-01
 SELECT asText(tgeompoint(th3index '871fa44a8ffffff@2001-01-01'), 6);
 -- POINT(4.297401 50.8043)@2001-01-01
+SELECT ST_AsText(cellToPoint(quadbin '48a6227affffffff'), 6);
+-- POINT(4.394531 50.847573)
 SELECT asText(cellToPoint(tquadbin '48a6227affffffff@2001-01-01'), 6);
 -- POINT(4.394531 50.847573)@2001-01-01
+SELECT ST_AsText(cellToPoint(s2cell '47c3c'), 6);
+-- POINT(4.222019 50.936164)
 SELECT asText(cellToPoint(ts2cell '47c3c@2001-01-01'), 6);
 -- POINT(4.222019 50.936164)@2001-01-01
 </programlisting>
@@ -1063,10 +1121,24 @@ expandSpace(tcell,float) &#8594; stbox
 </programlisting>
 				<para>El cuadro es la envolvente geodésica de las fronteras de las celdas junto con el período de tiempo de la trayectoria, de modo que es la clave que almacenan ambas clases de operadores de índice de la sección de indexación.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT round(stbox(th3index '871fa44a8ffffff@2001-01-01'), 6);
+/* SRID=4326;GEODSTBOX XT(((4.280027,50.79295),(4.314775,50.815648)),
+   [2001-01-01, 2001-01-01]) */
+SELECT round(expandSpace(th3index '871fa44a8ffffff@2001-01-01', 1), 6);
+/* SRID=4326;GEODSTBOX XT(((3.280027,49.79295),(5.314775,51.815648)),
+   [2001-01-01, 2001-01-01]) */
 SELECT round(stbox(tquadbin '48a6227affffffff@2001-01-01'), 6);
--- SRID=4326;STBOX XT(((4.21875,50.736455),(4.570313,50.958427)),[2001-01-01, 2001-01-01])
+/* SRID=4326;STBOX XT(((4.21875,50.736455),(4.570313,50.958427)),
+   [2001-01-01, 2001-01-01]) */
 SELECT round(expandSpace(tquadbin '48a6227affffffff@2001-01-01', 1), 6);
--- SRID=4326;STBOX XT(((3.21875,49.736455),(5.570313,51.958427)),[2001-01-01, 2001-01-01])
+/* SRID=4326;STBOX XT(((3.21875,49.736455),(5.570313,51.958427)),
+   [2001-01-01, 2001-01-01]) */
+SELECT round(stbox(ts2cell '47c3c@2001-01-01'), 6);
+/* SRID=4326;GEODSTBOX XT(((3.780069,50.590023),(4.676786,51.283168)),
+   [2001-01-01, 2001-01-01]) */
+SELECT round(expandSpace(ts2cell '47c3c@2001-01-01', 1), 6);
+/* SRID=4326;GEODSTBOX XT(((2.780069,49.590023),(5.676786,52.283168)),
+   [2001-01-01, 2001-01-01]) */
 </programlisting>
 			</listitem>
 			<listitem xml:id="tcell_overlaps">
@@ -1135,9 +1207,9 @@ SELECT tquadbin '485623ffffffffff@2001-01-01' &lt;&lt;# tquadbin '48b6227abfffff
 -- t
 SELECT tquadbin '485623ffffffffff@2001-01-01' #&gt;&gt; tquadbin '48b6227abfffffff@2001-01-05';
 -- f
-SELECT ts2cell '47c3c@2001-01-01' &lt;&lt;# ts2cell '47c3c@2001-01-05';
+SELECT ts2cell '47c3c@2001-01-01' &lt;&lt;# ts2cell '47c4@2001-01-05';
 -- t
-SELECT ts2cell '47c3c@2001-01-01' #&gt;&gt; ts2cell '47c3c@2001-01-05';
+SELECT ts2cell '47c3c@2001-01-01' #&gt;&gt; ts2cell '47c4@2001-01-05';
 -- f
 </programlisting>
 			</listitem>
@@ -1301,10 +1373,10 @@ SELECT eIntersects(geometry 'SRID=4326;Polygon((4.2 50.7,4.5 50.7,4.5 50.9,
   4.2 50.9,4.2 50.7))', th3index '871fa4418ffffff@2001-01-01');
 -- t
 SELECT eIntersects(geometry 'SRID=4326;Polygon((4.2 50.7,4.5 50.7,4.5 50.9,
-  4.2 50.9,4.2 50.7))', ts2cell '47c3c@2001-01-01');
+  4.2 50.9,4.2 50.7))', tquadbin '48a6227affffffff@2001-01-01');
 -- t
 SELECT eIntersects(geometry 'SRID=4326;Polygon((4.2 50.7,4.5 50.7,4.5 50.9,
-  4.2 50.9,4.2 50.7))', tquadbin '48a6227affffffff@2001-01-01');
+  4.2 50.9,4.2 50.7))', ts2cell '47c3c@2001-01-01');
 -- t
 </programlisting>
 			</listitem>
@@ -1364,8 +1436,8 @@ tcell {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tcell → boolean
 			<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '831c02fffffffff@2001-01-01' = th3index '831c02fffffffff@2001-01-01';
 -- t
-SELECT tquadbin '48a6227affffffff@2001-01-01' &lt; tquadbin '485623ffffffffff@2001-01-01';
--- f
+SELECT tquadbin '48a6227affffffff@2001-01-01' = tquadbin '48a6227affffffff@2001-01-01';
+-- t
 SELECT ts2cell '47c3c@2001-01-01' = ts2cell '47c3c@2001-01-01';
 -- t
 </programlisting>
@@ -1386,9 +1458,10 @@ SELECT th3index '[831c02fffffffff@2001-01-01,
   880326b885fffff@2001-01-05]' ?= h3index '880326b885fffff';
 -- t
 SELECT tquadbin '[48a6227affffffff@2001-01-01,
-  485623ffffffffff@2001-01-05]' %= quadbin '485623ffffffffff';
--- f
-SELECT ts2cell '47c3c@2001-01-01' ?= s2cell '47c3c';
+  485623ffffffffff@2001-01-05]' ?= quadbin '485623ffffffffff';
+-- t
+SELECT ts2cell '[47c3c@2001-01-01,
+  47c4@2001-01-05]' ?= s2cell '47c4';
 -- t
 </programlisting>
 		</listitem>
@@ -1404,7 +1477,7 @@ SELECT ts2cell '47c3c@2001-01-01' ?= s2cell '47c3c';
 			<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '831c02fffffffff@2001-01-01' #= h3index '831c02fffffffff';
 -- t@2001-01-01
-SELECT tquadbin '48a6227affffffff@2001-01-01' #&lt;&gt; quadbin '485623ffffffffff';
+SELECT tquadbin '48a6227affffffff@2001-01-01' #= quadbin '48a6227affffffff';
 -- t@2001-01-01
 SELECT ts2cell '47c3c@2001-01-01' #= s2cell '47c3c';
 -- t@2001-01-01
@@ -1446,13 +1519,8 @@ SELECT DISTINCT tile FROM elevation_tiles;
 tCount(tcell) → {tintSeq,tintSeqSet}
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-WITH Temp(temp) AS (
-  SELECT th3index '[831c02fffffffff@2001-01-01, 831c02fffffffff@2001-01-03)' UNION
-  SELECT th3index '[831c00fffffffff@2001-01-02, 831c00fffffffff@2001-01-04)' UNION
-  SELECT th3index '[871fa44a8ffffff@2001-01-03, 871fa44a8ffffff@2001-01-05)' )
-SELECT tCount(Temp)
-FROM Temp;
--- {[1@2001-01-01, 2@2001-01-02, 1@2001-01-04, 1@2001-01-05)}
+SELECT tCount(temp) FROM (VALUES (th3index '831c02fffffffff@2001-01-01')) AS t(temp);
+-- {1@2001-01-01}
 SELECT tCount(temp) FROM (VALUES (tquadbin '48a6227affffffff@2001-01-01')) AS t(temp);
 -- {1@2001-01-01}
 SELECT tCount(temp) FROM (VALUES (ts2cell '47c3c@2001-01-01')) AS t(temp);
@@ -1467,13 +1535,9 @@ SELECT tCount(temp) FROM (VALUES (ts2cell '47c3c@2001-01-01')) AS t(temp);
 wCount(tcell) → {tintSeq,tintSeqSet}
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-WITH Temp(temp) AS (
-  SELECT th3index '[831c02fffffffff@2001-01-01, 831c02fffffffff@2001-01-03)' UNION
-  SELECT th3index '[831c00fffffffff@2001-01-02, 831c00fffffffff@2001-01-04)' UNION
-  SELECT th3index '[871fa44a8ffffff@2001-01-03, 871fa44a8ffffff@2001-01-05)' )
-SELECT wCount(Temp, interval '1 day')
-FROM Temp;
--- {[1@2001-01-01, 2@2001-01-02, 3@2001-01-03, 2@2001-01-04, 1@2001-01-05, 1@2001-01-06)}
+SELECT wCount(temp, interval '1 day') FROM (VALUES
+  (th3index '831c02fffffffff@2001-01-01')) AS t(temp);
+-- {[1@2001-01-01, 1@2001-01-02]}
 SELECT wCount(temp, interval '1 day') FROM (VALUES
   (tquadbin '48a6227affffffff@2001-01-01')) AS t(temp);
 -- {[1@2001-01-01, 1@2001-01-02]}

--- a/doc/temporal_cell_index.xml
+++ b/doc/temporal_cell_index.xml
@@ -95,8 +95,20 @@ text(tcell) → text
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '831c02fffffffff@2001-01-01';
 -- 831c02fffffffff@2001-01-01
+SELECT th3index '[831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02]';
+-- [831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02]
+SELECT th3index '{[831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02]}';
+-- {[831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02]}
+SELECT tquadbin '48a6227affffffff@2001-01-01';
+-- 48a6227affffffff@2001-01-01
 SELECT tquadbin '[48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-02]';
 -- [48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-02]
+SELECT tquadbin '{[48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-02]}';
+-- {[48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-02]}
+SELECT ts2cell '47c3c@2001-01-01';
+-- 47c3c@2001-01-01
+SELECT ts2cell '[47c3c@2001-01-01, 47c4@2001-01-02]';
+-- [47c3c@2001-01-01, 47c4@2001-01-02]
 SELECT ts2cell '{[47c3c@2001-01-01, 47c4@2001-01-02]}';
 -- {[47c3c@2001-01-01, 47c4@2001-01-02]}
 </programlisting>
@@ -450,9 +462,8 @@ getValues(tcell) → cellset
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getValues(th3index '831c02fffffffff@2001-01-01');
 -- {"831c02fffffffff"}
-SELECT getValues(th3index '[831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02,
-    880326b885fffff@2001-01-03]');
--- {"831c00fffffffff", "831c02fffffffff", "880326b885fffff"}
+SELECT getValues(th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02}');
+-- {"831c00fffffffff", "831c02fffffffff"}
 SELECT getValues(tquadbin '48a6227affffffff@2001-01-01');
 -- {"48a6227affffffff"}
 SELECT getValues(tquadbin '{48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-02}');
@@ -477,7 +488,8 @@ SELECT valueAtTimestamp(th3index
 SELECT valueAtTimestamp(tquadbin
   '[48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-05]', '2001-01-03');
 -- 48a6227affffffff
-SELECT valueAtTimestamp(ts2cell '47c3c@2001-01-01', timestamptz '2001-01-01');
+SELECT valueAtTimestamp(ts2cell
+  '[47c3c@2001-01-01, 47c4@2001-01-05]', '2001-01-03');
 -- 47c3c
 </programlisting>
 			</listitem>
@@ -702,9 +714,21 @@ appendSequence(tcell,tcellSeq) &#8594; tcell
 SELECT asText(appendInstant(th3index '831c02fffffffff@2001-01-01',
   th3index '831c00fffffffff@2001-01-02'));
 -- [831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02]
+SELECT asText(appendSequence(th3index '[831c02fffffffff@2001-01-01]',
+  th3index '[831c00fffffffff@2001-01-02]'));
+-- {[831c02fffffffff@2001-01-01], [831c00fffffffff@2001-01-02]}
+SELECT asText(appendInstant(tquadbin '48a6227affffffff@2001-01-01',
+  tquadbin '485623ffffffffff@2001-01-02'));
+-- [48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-02]
 SELECT asText(appendSequence(tquadbin '[48a6227affffffff@2001-01-01]',
   tquadbin '[485623ffffffffff@2001-01-02]'));
 -- {[48a6227affffffff@2001-01-01], [485623ffffffffff@2001-01-02]}
+SELECT asText(appendInstant(ts2cell '47c3c@2001-01-01',
+  ts2cell '47c4@2001-01-02'));
+-- [47c3c@2001-01-01, 47c4@2001-01-02]
+SELECT asText(appendSequence(ts2cell '[47c3c@2001-01-01]',
+  ts2cell '[47c4@2001-01-02]'));
+-- {[47c3c@2001-01-01], [47c4@2001-01-02]}
 </programlisting>
 			</listitem>
 
@@ -716,12 +740,24 @@ merge(tcell,tcell) &#8594; tcell
 merge(tcell[]) &#8594; tcell
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT asText(merge(ts2cell '[47c3c@2001-01-01, 47c3c@2001-01-03]',
-  ts2cell '[47c3c@2001-01-03, 47c4@2001-01-05]'));
--- [47c3c@2001-01-01, 47c4@2001-01-05]
+SELECT asText(merge(th3index '[831c02fffffffff@2001-01-01, 831c02fffffffff@2001-01-03]',
+  th3index '[831c02fffffffff@2001-01-03, 831c00fffffffff@2001-01-05]'));
+-- [831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-05]
 SELECT asText(merge(ARRAY[th3index '831c02fffffffff@2001-01-01',
   th3index '831c00fffffffff@2001-01-03']));
 -- {831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-03}
+SELECT asText(merge(tquadbin '[48a6227affffffff@2001-01-01, 48a6227affffffff@2001-01-03]',
+  tquadbin '[48a6227affffffff@2001-01-03, 485623ffffffffff@2001-01-05]'));
+-- [48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-05]
+SELECT asText(merge(ARRAY[tquadbin '48a6227affffffff@2001-01-01',
+  tquadbin '485623ffffffffff@2001-01-03']));
+-- {48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-03}
+SELECT asText(merge(ts2cell '[47c3c@2001-01-01, 47c3c@2001-01-03]',
+  ts2cell '[47c3c@2001-01-03, 47c4@2001-01-05]'));
+-- [47c3c@2001-01-01, 47c4@2001-01-05]
+SELECT asText(merge(ARRAY[ts2cell '47c3c@2001-01-01',
+  ts2cell '47c4@2001-01-03']));
+-- {47c3c@2001-01-01, 47c4@2001-01-03}
 </programlisting>
 			</listitem>
 
@@ -738,8 +774,9 @@ SELECT setInterp(th3index '{871fa4418ffffff@2001-01-01,
 SELECT setInterp(tquadbin '{48a6227affffffff@2001-01-01,
   485623ffffffffff@2001-01-02}', 'step');
 -- {[48a6227affffffff@2001-01-01], [485623ffffffffff@2001-01-02]}
-SELECT setInterp(ts2cell '{47c3c@2001-01-01}', 'step');
--- [47c3c@2001-01-01]
+SELECT setInterp(ts2cell '{47c3c@2001-01-01,
+  47c4@2001-01-02}', 'step');
+-- {[47c3c@2001-01-01], [47c4@2001-01-02]}
 </programlisting>
 			</listitem>
 		</itemizedlist>
@@ -765,8 +802,10 @@ SELECT insert(tquadbin '[48a6227affffffff@2001-01-01,
   485623ffffffffff@2001-01-04]');
 /* [48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-03,
    485623ffffffffff@2001-01-04] */
-SELECT insert(ts2cell '47c3c@2001-01-01', ts2cell '47c4@2001-01-02');
--- {47c3c@2001-01-01, 47c4@2001-01-02}
+SELECT insert(ts2cell '[47c3c@2001-01-01,
+  47c3c@2001-01-02]', ts2cell '[47c4@2001-01-03,
+  47c4@2001-01-04]');
+-- [47c3c@2001-01-01, 47c4@2001-01-03, 47c4@2001-01-04]
 </programlisting>
 			</listitem>
 
@@ -783,8 +822,9 @@ SELECT deleteTime(th3index '[871fa4418ffffff@2001-01-01,
 SELECT deleteTime(tquadbin '[48a6227affffffff@2001-01-01,
   48a6227affffffff@2001-01-04]', tstzspan '[2001-01-02, 2001-01-03]');
 -- [48a6227affffffff@2001-01-01, 48a6227affffffff@2001-01-04]
-SELECT deleteTime(ts2cell '47c3c@2001-01-01', tstzspan '[2001-01-02, 2001-01-03]');
--- 47c3c@2001-01-01
+SELECT deleteTime(ts2cell '[47c3c@2001-01-01,
+  47c3c@2001-01-04]', tstzspan '[2001-01-02, 2001-01-03]');
+-- [47c3c@2001-01-01, 47c3c@2001-01-04]
 </programlisting>
 			</listitem>
 		</itemizedlist>
@@ -811,8 +851,9 @@ SELECT atValue(th3index '{871fa4418ffffff@2001-01-01,
 SELECT atValue(tquadbin '{48a6227affffffff@2001-01-01, 485623ffffffffff@2001-01-02}',
   quadbin '48a6227affffffff');
 -- {48a6227affffffff@2001-01-01}
-SELECT atValue(ts2cell '47c3c@2001-01-01', s2cell '47c3c');
--- 47c3c@2001-01-01
+SELECT atValue(ts2cell '{47c3c@2001-01-01, 47c4@2001-01-02}',
+  s2cell '47c3c');
+-- {47c3c@2001-01-01}
 </programlisting>
 			</listitem>
 
@@ -831,8 +872,9 @@ SELECT atTime(th3index '[871fa4418ffffff@2001-01-01,
 SELECT atTime(tquadbin '[48a6227affffffff@2001-01-01, 48a6227affffffff@2001-01-04]',
   tstzspan '[2001-01-02, 2001-01-03]');
 -- [48a6227affffffff@2001-01-02, 48a6227affffffff@2001-01-03]
-SELECT atTime(ts2cell '47c3c@2001-01-01', tstzspan '[2001-01-01, 2001-01-02]');
--- 47c3c@2001-01-01
+SELECT atTime(ts2cell '[47c3c@2001-01-01, 47c3c@2001-01-04]',
+  tstzspan '[2001-01-02, 2001-01-03]');
+-- [47c3c@2001-01-02, 47c3c@2001-01-03]
 </programlisting>
 			</listitem>
 		</itemizedlist>
@@ -908,8 +950,12 @@ SELECT getResolution(h3index '831c02fffffffff');
 -- 3
 SELECT getResolution(th3index '831c02fffffffff@2001-01-01');
 -- 3@2001-01-01
+SELECT getResolution(quadbin '48a6227affffffff');
+-- 10
 SELECT getResolution(tquadbin '48a6227affffffff@2001-01-01');
 -- 10@2001-01-01
+SELECT getResolution(s2cell '47c3c');
+-- 7
 SELECT getResolution(ts2cell '47c3c@2001-01-01');
 -- 7@2001-01-01
 </programlisting>
@@ -926,14 +972,18 @@ isValidCell(tcell) → tbool
 				<para>A value is a valid cell when its bit pattern denotes something its grid indexes: for QUADBIN, tile coordinates within the bounds of the resolution the identifier states; for H3, a base cell and digit sequence the icosahedron carries; for S2, a face and a Hilbert position at a level between 0 and 30.</para>
 				<para>Only H3 can be asked the question of a value that answers <varname>false</varname>: its input function admits any bit pattern and leaves the verdict to this function, while the QUADBIN and the S2 input functions reject a pattern that indexes nothing, so <varname>tquadbin '0'</varname> and <varname>ts2cell '0'</varname> raise an error before the call is made.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT isValidCell(quadbin '48a6227affffffff');
+SELECT isValidCell(h3index '831c02fffffffff');
 -- t
 SELECT isValidCell(th3index '831c02fffffffff@2001-01-01');
 -- t@2001-01-01
 SELECT isValidCell(th3index '0@2001-01-01');
 -- f@2001-01-01
+SELECT isValidCell(quadbin '48a6227affffffff');
+-- t
 SELECT isValidCell(tquadbin '48a6227affffffff@2001-01-01');
 -- t@2001-01-01
+SELECT isValidCell(s2cell '47c3c');
+-- t
 SELECT isValidCell(ts2cell '47c3c@2001-01-01');
 -- t@2001-01-01
 </programlisting>
@@ -955,13 +1005,17 @@ cellToParent(tcell) → tcell
 </programlisting>
 				<para>Return the ancestor of a cell at the given coarser resolution. The static form takes a single <varname>cell</varname>; the temporal form returns the ancestor of each cell in a trajectory. The no-argument form drops to the next-coarser resolution.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT cellToParent(h3index '8a2a1072b59ffff', 5);
--- 852a1073fffffff
+SELECT getResolution(cellToParent(h3index '8a2a1072b59ffff', 5));
+-- 5
 SELECT getResolution(cellToParent(th3index '8a2a1072b59ffff@2001-01-01', 5));
 -- 5@2001-01-01
+SELECT getResolution(cellToParent(quadbin '48a6227affffffff', 5));
+-- 5
 SELECT getResolution(cellToParent(tquadbin
   '48a6227affffffff@2001-01-01', 5));
 -- 5@2001-01-01
+SELECT getResolution(cellToParent(s2cell '47c3c', 5));
+-- 5
 SELECT getResolution(cellToParent(ts2cell '47c3c@2001-01-01', 5));
 -- 5@2001-01-01
 </programlisting>
@@ -1008,8 +1062,12 @@ SELECT asText(cellToPoint(th3index '871fa44a8ffffff@2001-01-01'), 6);
 -- POINT(4.297401 50.8043)@2001-01-01
 SELECT asText(tgeompoint(th3index '871fa44a8ffffff@2001-01-01'), 6);
 -- POINT(4.297401 50.8043)@2001-01-01
+SELECT ST_AsText(cellToPoint(quadbin '48a6227affffffff'), 6);
+-- POINT(4.394531 50.847573)
 SELECT asText(cellToPoint(tquadbin '48a6227affffffff@2001-01-01'), 6);
 -- POINT(4.394531 50.847573)@2001-01-01
+SELECT ST_AsText(cellToPoint(s2cell '47c3c'), 6);
+-- POINT(4.222019 50.936164)
 SELECT asText(cellToPoint(ts2cell '47c3c@2001-01-01'), 6);
 -- POINT(4.222019 50.936164)@2001-01-01
 </programlisting>
@@ -1065,10 +1123,24 @@ expandSpace(tcell,float) &#8594; stbox
 </programlisting>
 				<para>The box is the geodetic envelope of the cell boundaries together with the trajectory's time period, so it is the key both index operator classes of the indexing section store.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT round(stbox(th3index '871fa44a8ffffff@2001-01-01'), 6);
+/* SRID=4326;GEODSTBOX XT(((4.280027,50.79295),(4.314775,50.815648)),
+   [2001-01-01, 2001-01-01]) */
+SELECT round(expandSpace(th3index '871fa44a8ffffff@2001-01-01', 1), 6);
+/* SRID=4326;GEODSTBOX XT(((3.280027,49.79295),(5.314775,51.815648)),
+   [2001-01-01, 2001-01-01]) */
 SELECT round(stbox(tquadbin '48a6227affffffff@2001-01-01'), 6);
--- SRID=4326;STBOX XT(((4.21875,50.736455),(4.570313,50.958427)),[2001-01-01, 2001-01-01])
+/* SRID=4326;STBOX XT(((4.21875,50.736455),(4.570313,50.958427)),
+   [2001-01-01, 2001-01-01]) */
 SELECT round(expandSpace(tquadbin '48a6227affffffff@2001-01-01', 1), 6);
--- SRID=4326;STBOX XT(((3.21875,49.736455),(5.570313,51.958427)),[2001-01-01, 2001-01-01])
+/* SRID=4326;STBOX XT(((3.21875,49.736455),(5.570313,51.958427)),
+   [2001-01-01, 2001-01-01]) */
+SELECT round(stbox(ts2cell '47c3c@2001-01-01'), 6);
+/* SRID=4326;GEODSTBOX XT(((3.780069,50.590023),(4.676786,51.283168)),
+   [2001-01-01, 2001-01-01]) */
+SELECT round(expandSpace(ts2cell '47c3c@2001-01-01', 1), 6);
+/* SRID=4326;GEODSTBOX XT(((2.780069,49.590023),(5.676786,52.283168)),
+   [2001-01-01, 2001-01-01]) */
 </programlisting>
 			</listitem>
 
@@ -1138,9 +1210,9 @@ SELECT tquadbin '485623ffffffffff@2001-01-01' &lt;&lt;# tquadbin '48b6227abfffff
 -- t
 SELECT tquadbin '485623ffffffffff@2001-01-01' #&gt;&gt; tquadbin '48b6227abfffffff@2001-01-05';
 -- f
-SELECT ts2cell '47c3c@2001-01-01' &lt;&lt;# ts2cell '47c3c@2001-01-05';
+SELECT ts2cell '47c3c@2001-01-01' &lt;&lt;# ts2cell '47c4@2001-01-05';
 -- t
-SELECT ts2cell '47c3c@2001-01-01' #&gt;&gt; ts2cell '47c3c@2001-01-05';
+SELECT ts2cell '47c3c@2001-01-01' #&gt;&gt; ts2cell '47c4@2001-01-05';
 -- f
 </programlisting>
 			</listitem>
@@ -1304,10 +1376,10 @@ SELECT eIntersects(geometry 'SRID=4326;Polygon((4.2 50.7,4.5 50.7,4.5 50.9,
   4.2 50.9,4.2 50.7))', th3index '871fa4418ffffff@2001-01-01');
 -- t
 SELECT eIntersects(geometry 'SRID=4326;Polygon((4.2 50.7,4.5 50.7,4.5 50.9,
-  4.2 50.9,4.2 50.7))', ts2cell '47c3c@2001-01-01');
+  4.2 50.9,4.2 50.7))', tquadbin '48a6227affffffff@2001-01-01');
 -- t
 SELECT eIntersects(geometry 'SRID=4326;Polygon((4.2 50.7,4.5 50.7,4.5 50.9,
-  4.2 50.9,4.2 50.7))', tquadbin '48a6227affffffff@2001-01-01');
+  4.2 50.9,4.2 50.7))', ts2cell '47c3c@2001-01-01');
 -- t
 </programlisting>
 			</listitem>
@@ -1367,8 +1439,8 @@ tcell {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tcell → boolean
 			<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '831c02fffffffff@2001-01-01' = th3index '831c02fffffffff@2001-01-01';
 -- t
-SELECT tquadbin '48a6227affffffff@2001-01-01' &lt; tquadbin '485623ffffffffff@2001-01-01';
--- f
+SELECT tquadbin '48a6227affffffff@2001-01-01' = tquadbin '48a6227affffffff@2001-01-01';
+-- t
 SELECT ts2cell '47c3c@2001-01-01' = ts2cell '47c3c@2001-01-01';
 -- t
 </programlisting>
@@ -1389,9 +1461,10 @@ SELECT th3index '[831c02fffffffff@2001-01-01,
   880326b885fffff@2001-01-05]' ?= h3index '880326b885fffff';
 -- t
 SELECT tquadbin '[48a6227affffffff@2001-01-01,
-  485623ffffffffff@2001-01-05]' %= quadbin '485623ffffffffff';
--- f
-SELECT ts2cell '47c3c@2001-01-01' ?= s2cell '47c3c';
+  485623ffffffffff@2001-01-05]' ?= quadbin '485623ffffffffff';
+-- t
+SELECT ts2cell '[47c3c@2001-01-01,
+  47c4@2001-01-05]' ?= s2cell '47c4';
 -- t
 </programlisting>
 		</listitem>
@@ -1407,7 +1480,7 @@ SELECT ts2cell '47c3c@2001-01-01' ?= s2cell '47c3c';
 			<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '831c02fffffffff@2001-01-01' #= h3index '831c02fffffffff';
 -- t@2001-01-01
-SELECT tquadbin '48a6227affffffff@2001-01-01' #&lt;&gt; quadbin '485623ffffffffff';
+SELECT tquadbin '48a6227affffffff@2001-01-01' #= quadbin '48a6227affffffff';
 -- t@2001-01-01
 SELECT ts2cell '47c3c@2001-01-01' #= s2cell '47c3c';
 -- t@2001-01-01
@@ -1449,13 +1522,8 @@ SELECT DISTINCT tile FROM elevation_tiles;
 tCount(tcell) → {tintSeq,tintSeqSet}
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-WITH Temp(temp) AS (
-  SELECT th3index '[831c02fffffffff@2001-01-01, 831c02fffffffff@2001-01-03)' UNION
-  SELECT th3index '[831c00fffffffff@2001-01-02, 831c00fffffffff@2001-01-04)' UNION
-  SELECT th3index '[871fa44a8ffffff@2001-01-03, 871fa44a8ffffff@2001-01-05)' )
-SELECT tCount(Temp)
-FROM Temp;
--- {[1@2001-01-01, 2@2001-01-02, 1@2001-01-04, 1@2001-01-05)}
+SELECT tCount(temp) FROM (VALUES (th3index '831c02fffffffff@2001-01-01')) AS t(temp);
+-- {1@2001-01-01}
 SELECT tCount(temp) FROM (VALUES (tquadbin '48a6227affffffff@2001-01-01')) AS t(temp);
 -- {1@2001-01-01}
 SELECT tCount(temp) FROM (VALUES (ts2cell '47c3c@2001-01-01')) AS t(temp);
@@ -1470,13 +1538,9 @@ SELECT tCount(temp) FROM (VALUES (ts2cell '47c3c@2001-01-01')) AS t(temp);
 wCount(tcell) → {tintSeq,tintSeqSet}
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-WITH Temp(temp) AS (
-  SELECT th3index '[831c02fffffffff@2001-01-01, 831c02fffffffff@2001-01-03)' UNION
-  SELECT th3index '[831c00fffffffff@2001-01-02, 831c00fffffffff@2001-01-04)' UNION
-  SELECT th3index '[871fa44a8ffffff@2001-01-03, 871fa44a8ffffff@2001-01-05)' )
-SELECT wCount(Temp, interval '1 day')
-FROM Temp;
--- {[1@2001-01-01, 2@2001-01-02, 3@2001-01-03, 2@2001-01-04, 1@2001-01-05, 1@2001-01-06)}
+SELECT wCount(temp, interval '1 day') FROM (VALUES
+  (th3index '831c02fffffffff@2001-01-01')) AS t(temp);
+-- {[1@2001-01-01, 1@2001-01-02]}
 SELECT wCount(temp, interval '1 day') FROM (VALUES
   (tquadbin '48a6227affffffff@2001-01-01')) AS t(temp);
 -- {[1@2001-01-01, 1@2001-01-02]}

--- a/doc/temporal_cell_index.xml
+++ b/doc/temporal_cell_index.xml
@@ -1106,7 +1106,7 @@ SELECT ST_NPoints(getValue(cellToBoundary(ts2cell '47c3c@2001-01-01'))::geometry
 	</sect1>
 	<sect1 xml:id="tcell_bbox_ops">
 		<title>Bounding Box Operations</title>
-		<para>The following operators compare the spatiotemporal <emphasis>bounding box</emphasis> of temporal cells rather than containment in the cell hierarchy. <varname>tcell</varname> is a spatial temporal type: its bounding box is an <varname>stbox</varname> that combines the geodetic spatial extent of the cell boundaries (their longitude/latitude envelope in SRID 4326) with the trajectory's <varname>tstzspan</varname> time period. The operators below compare that box along the spatial and/or temporal axes. See the indexing section for the opclasses that make these operators index-capable.</para>
+		<para>The following operators compare the spatiotemporal <emphasis>bounding box</emphasis> of temporal cells rather than containment in the cell hierarchy. <varname>tcell</varname> is a spatial temporal type: its bounding box is an <varname>stbox</varname> that combines the spatial extent of the cell boundaries (their longitude/latitude envelope in SRID 4326), geodetic for an H3 or S2 cell and planar for a QUADBIN cell, with the trajectory's <varname>tstzspan</varname> time period. The operators below compare that box along the spatial and/or temporal axes. See the indexing section for the opclasses that make these operators index-capable.</para>
 
 		<note>
 			<para>The <varname>@&gt;</varname> operator tests spatiotemporal bounding-box containment (spatial extent and time together), <emphasis>not</emphasis> containment in the cell hierarchy. To test whether one cell is the ancestor of another at a given resolution, use <link linkend="tcell_cell_to_parent"><varname>cellToParent</varname></link>.</para>
@@ -1121,7 +1121,7 @@ SELECT ST_NPoints(getValue(cellToBoundary(ts2cell '47c3c@2001-01-01'))::geometry
 stbox(tcell) &#8594; stbox
 expandSpace(tcell,float) &#8594; stbox
 </programlisting>
-				<para>The box is the geodetic envelope of the cell boundaries together with the trajectory's time period, so it is the key both index operator classes of the indexing section store.</para>
+				<para>The box is the envelope of the cell boundaries, geodetic for an H3 or S2 cell and planar for a QUADBIN cell, together with the trajectory's time period, so it is the key both index operator classes of the indexing section store.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(stbox(th3index '871fa44a8ffffff@2001-01-01'), 6);
 /* SRID=4326;GEODSTBOX XT(((4.280027,50.79295),(4.314775,50.815648)),
@@ -1578,7 +1578,7 @@ SELECT mergeAgg(temp) FROM (VALUES (ts2cell '47c3c@2001-01-01')) AS t(temp);
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE INDEX Trips_Cells_SPGist_Idx ON Trips USING SPGist(Cells);
 </programlisting>
-		<para>The GiST and SP-GiST indexes store the bounding box for the temporal cells, which is an <varname>stbox</varname>, as all spatiotemporal types: the geodetic extent of the cell boundaries together with the time period.</para>
+		<para>The GiST and SP-GiST indexes store the bounding box for the temporal cells, which is an <varname>stbox</varname>, as all spatiotemporal types: the extent of the cell boundaries, geodetic for H3 and S2 cells and planar for QUADBIN cells, together with the time period.</para>
 
 		<para>Each operator class carries the name of the temporal type it indexes, so a <varname>th3index</varname> column takes <varname>th3index_rtree_ops</varname> for GiST and <varname>th3index_quadtree_ops</varname> or <varname>th3index_kdtree_ops</varname> for SP-GiST, and the <varname>tquadbin</varname> and <varname>ts2cell</varname> names likewise. The quadtree class is the SP-GiST default and the k-d tree class is named explicitly. A B-tree and a hash operator class are defined as well, ordering and hashing by the underlying temporal value.</para>
 


### PR DESCRIPTION
State the examples of each tessellation entry in one shape

An entry of the tessellations chapter that documents a function or an
operator for several grids states its examples in one shape, so that the
examples of H3, QUADBIN and S2 differ only in the type and its literal. The
shape is the one most of the entry's examples take; where an entry shows a
form for some grids only, it shows every form the SQL defines for every
grid, and a static cell form stands beside the temporal one for each grid.

The shape holds for the input and output of a temporal cell, getValues,
valueAtTimestamp, appendInstant and appendSequence, merge, setInterp,
insert, deleteTime, atValue, atTime, getResolution, isValidCell,
cellToParent, cellToPoint, stbox and expandSpace, the temporal position
operators, the ever relationships, the traditional, ever and temporal
comparisons, tCount and wCount. The box of an H3 or an S2 cell is a
geodetic GEODSTBOX and the box of a QUADBIN cell a planar STBOX, which the
stbox examples state for the three grids.

Every result comment is the output of the statement above it, and the
Spanish chapter carries the same listings.


State the bounding box of a cell as geodetic or planar, as its grid answers it

The bounding box of a temporal cell is the envelope of the cell boundaries in
SRID 4326 together with the time period of the trajectory. It is a geodetic
box for an H3 or S2 cell and a planar box for a QUADBIN cell: stbox answers
SRID=4326;GEODSTBOX XT(...) for th3index '871fa44a8ffffff@2001-01-01' and
SRID=4326;STBOX XT(...) for tquadbin '48a6227affffffff@2001-01-01', as the
examples of the stbox entry show.

The introduction of the bounding box operations, the stbox entry and the
indexing section state the kind of box per grid, in English and Spanish.


