### PR TITLE
Read point coordinates in place where the native engine only reads them

### DIFF
--- a/meos/include/rgeo/trgeo_vclip.h
+++ b/meos/include/rgeo/trgeo_vclip.h
@@ -94,10 +94,10 @@ uint_mod_sub(uint32_t i, uint32_t j, uint32_t n)
  * 1 < s      -> p after point ve
  */
 static inline double
-compute_s(POINT4D p, POINT4D vs, POINT4D ve)
+compute_s(const POINT2D *p, const POINT2D *vs, const POINT2D *ve)
 {
-  return ((p.x - vs.x) * (ve.x - vs.x) + (p.y - vs.y) * (ve.y - vs.y)) /
-    ((ve.x - vs.x) * (ve.x - vs.x) + (ve.y - vs.y) * (ve.y - vs.y));
+  return ((p->x - vs->x) * (ve->x - vs->x) + (p->y - vs->y) * (ve->y - vs->y)) /
+    ((ve->x - vs->x) * (ve->x - vs->x) + (ve->y - vs->y) * (ve->y - vs->y));
 }
 
 extern int v_clip_tpoly_point(const LWPOLY *poly, const LWPOINT *point,
@@ -106,7 +106,7 @@ extern int v_clip_tpoly_tpoly(const LWPOLY *poly1, const LWPOLY *poly2,
   const Pose *pose1, const Pose *pose2, uint32_t *poly1_feature,
   uint32_t *poly2_feature, double *dist);
 
-extern void apply_pose_point4d(POINT4D *p, const Pose *pose);
+extern void apply_pose_point2d(POINT2D *p, const Pose *pose);
 
 /*****************************************************************************/
 

--- a/meos/src/cbuffer/cbuffer.c
+++ b/meos/src/cbuffer/cbuffer.c
@@ -571,17 +571,16 @@ geom_to_cbuffer(const GSERIALIZED *gs)
     int32_t srid = gserialized_get_srid(gs);
     LWCURVEPOLY *poly = (LWCURVEPOLY *) lwgeom_from_gserialized(gs);
     LWLINE *ring = (LWLINE *) poly->rings[0];
-    POINT4D p1, p2;
-    getPoint4d_p(ring->points, 0, &p1);
-    getPoint4d_p(ring->points, 1, &p2);
+    const POINT2D *p1 = getPoint2d_cp(ring->points, 0);
+    const POINT2D *p2 = getPoint2d_cp(ring->points, 1);
     /* The two points are the ends of a diameter, so the centre is halfway
      * between them and the radius is half of what separates them. We cannot
      * call the PostGIS function
      * interpolate_point4d(&p1, &p2, &p, ratio);
      * since it uses a double and not a long double for the interpolation */
-    double x = p1.x + (double) ((long double) (p2.x - p1.x) * 0.5);
-    double y = p1.y + (double) ((long double) (p2.y - p1.y) * 0.5);
-    radius = hypot(p2.x - p1.x, p2.y - p1.y) / 2;
+    double x = p1->x + (double) ((long double) (p2->x - p1->x) * 0.5);
+    double y = p1->y + (double) ((long double) (p2->y - p1->y) * 0.5);
+    radius = hypot(p2->x - p1->x, p2->y - p1->y) / 2;
     LWGEOM *center = (LWGEOM *) lwpoint_make2d(srid, x, y);
     gscenter = geom_serialize(center);
     lwgeom_free((LWGEOM *) poly); lwgeom_free(center); 

--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -297,11 +297,7 @@ buffer_snap_to_curve_end(const LWCOMPOUND *curve, POINT2D *point)
   const LWLINE *prev = (const LWLINE *) curve->geoms[curve->ngeoms - 1];
   if (! prev || ! prev->points || prev->points->npoints == 0)
     return;
-  POINT4D last;
-  getPoint4d_p(prev->points, prev->points->npoints - 1, &last);
-  POINT2D end;
-  end.x = last.x;
-  end.y = last.y;
+  POINT2D end = *getPoint2d_cp(prev->points, prev->points->npoints - 1);
   if (buffer_points_equal(end, *point))
     *point = end;
   return;
@@ -4324,10 +4320,9 @@ buffer_ring_area(const POINTARRAY *pa)
   double area = 0.0;
   for (uint32_t i = 0; i < pa->npoints - 1; i++)
   {
-    POINT4D p1, p2;
-    getPoint4d_p(pa, i, &p1);
-    getPoint4d_p(pa, i + 1, &p2);
-    area += p1.x * p2.y - p2.x * p1.y;
+    const POINT2D *p1 = getPoint2d_cp(pa, i);
+    const POINT2D *p2 = getPoint2d_cp(pa, i + 1);
+    area += p1->x * p2->y - p2->x * p1->y;
   }
   return area * 0.5;
 }
@@ -4381,12 +4376,7 @@ buffer_ring(const POINTARRAY *source, double radius, bool outward_left,
   uint32_t n = source->npoints - 1;
   POINT2D *points = palloc(sizeof(POINT2D) * n);
   for (uint32_t i = 0; i < n; i++)
-  {
-    POINT4D p;
-    getPoint4d_p(source, i, &p);
-    points[i].x = p.x;
-    points[i].y = p.y;
-  }
+    points[i] = *getPoint2d_cp(source, i);
 
   /* The unit normal of every segment, pointing to the buffered side */
   double *nx = palloc(sizeof(double) * n);
@@ -5839,9 +5829,8 @@ meos_buffer_point(const LWPOINT *point, double radius)
 {
   assert(point); assert(radius > 0.0);
   int32_t srid = lwgeom_get_srid((const LWGEOM *) point);
-  POINT4D pt;
-  lwpoint_getPoint4d_p(point, &pt);
-  return lwcircle_make(pt.x, pt.y, radius, srid);
+  const POINT2D *pt = getPoint2d_cp(point->point, 0);
+  return lwcircle_make(pt->x, pt->y, radius, srid);
 }
 
 /*****************************************************************************
@@ -5920,12 +5909,7 @@ meos_buffer_line_offset(const LWLINE *line, double radius,
   uint32_t npoints = line->points->npoints;
   POINT2D *points = palloc(sizeof(POINT2D) * npoints);
   for (uint32_t i = 0; i < npoints; i++)
-  {
-    POINT4D point;
-    getPoint4d_p(line->points, i, &point);
-    points[i].x = point.x;
-    points[i].y = point.y;
-  }
+    points[i] = *getPoint2d_cp(line->points, i);
 
   /* Remove duplicate consecutive points */
   uint32_t nvalid = 0;
@@ -6228,16 +6212,11 @@ meos_buffer_line_split(const LWLINE *line, double radius, JoinStyle join_style,
   uint32_t nvalid = 0;
   for (uint32_t i = 0; i < npoints; i++)
   {
-    POINT4D point;
-    getPoint4d_p(line->points, i, &point);
+    const POINT2D *point = getPoint2d_cp(line->points, i);
     if (nvalid == 0 ||
-        hypot(point.x - points[nvalid - 1].x,
-              point.y - points[nvalid - 1].y) > MEOS_GEOM_TOLERANCE)
-    {
-      points[nvalid].x = point.x;
-      points[nvalid].y = point.y;
-      nvalid++;
-    }
+        hypot(point->x - points[nvalid - 1].x,
+              point->y - points[nvalid - 1].y) > MEOS_GEOM_TOLERANCE)
+      points[nvalid++] = *point;
   }
   npoints = nvalid;
   if (npoints < 3)

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -67,12 +67,11 @@ emit_ring_edges(const POINTARRAY *pa, MeosArray *edges, EdgeType etype)
 {
   for (int i = 0; i < (int) pa->npoints - 1; i++)
   {
-    POINT4D a, b;
-    (void) getPoint4d_p(pa, i, &a);
-    (void) getPoint4d_p(pa, i + 1, &b);
+    const POINT2D *a = getPoint2d_cp(pa, i);
+    const POINT2D *b = getPoint2d_cp(pa, i + 1);
     Edge e;
-    e.x1 = a.x; e.y1 = a.y;
-    e.x2 = b.x; e.y2 = b.y;
+    e.x1 = a->x; e.y1 = a->y;
+    e.x2 = b->x; e.y2 = b->y;
     e.xmin = Min(e.x1, e.x2); e.xmax = Max(e.x1, e.x2);
     e.ymin = Min(e.y1, e.y2); e.ymax = Max(e.y1, e.y2);
     e.dx = e.x2 - e.x1; e.dy = e.y2 - e.y1;
@@ -95,11 +94,10 @@ extract_point(const LWPOINT *pt, MeosArray *edges)
    * closed trajectory) has no vertex to read; it contributes no edge. */
   if (! pt->point || pt->point->npoints < 1)
     return;
-  POINT4D p;
-  (void) getPoint4d_p(pt->point, 0, &p);
+  const POINT2D *p = getPoint2d_cp(pt->point, 0);
   Edge e;
-  e.x1 = e.x2 = e.xmin = e.xmax = p.x;
-  e.y1 = e.y2 = e.ymin = e.ymax = p.y;
+  e.x1 = e.x2 = e.xmin = e.xmax = p->x;
+  e.y1 = e.y2 = e.ymin = e.ymax = p->y;
   e.dx = e.dy = e.length = 0;
   e.etype = EDGE_POINT;
   edge_set_tolerance(&e);
@@ -236,7 +234,7 @@ extract_triangle(const LWTRIANGLE *tri, MeosArray *edges)
  * emitted as line edges
  */
 static void
-emit_arc_edge(const POINT4D *pa, const POINT4D *pb, const POINT4D *pc,
+emit_arc_edge(const POINT2D *pa, const POINT2D *pb, const POINT2D *pc,
   MeosArray *edges, EdgeType line_etype, EdgeType arc_etype)
 {
   /* The circumcentre below is read from the SQUARES of the coordinates, and
@@ -358,11 +356,8 @@ emit_circstring_edges(const LWCIRCSTRING *circ, MeosArray *edges,
   int np = (int) pa->npoints;
   for (int i = 0; i + 2 < np; i += 2)
   {
-    POINT4D pa4, pb4, pc4;
-    (void) getPoint4d_p(pa, i, &pa4);
-    (void) getPoint4d_p(pa, i + 1, &pb4);
-    (void) getPoint4d_p(pa, i + 2, &pc4);
-    emit_arc_edge(&pa4, &pb4, &pc4, edges, line_etype, arc_etype);
+    emit_arc_edge(getPoint2d_cp(pa, i), getPoint2d_cp(pa, i + 1),
+      getPoint2d_cp(pa, i + 2), edges, line_etype, arc_etype);
   }
   return;
 }
@@ -2550,16 +2545,14 @@ lwmpoint_is_simple(const LWMPOINT *mpoint)
     const LWPOINT *point1 = mpoint->geoms[i];
     if (! point1 || lwpoint_is_empty(point1))
       continue;
-    POINT2D p1;
-    lwpoint_getPoint2d_p(point1, &p1);
+    const POINT2D *p1 = getPoint2d_cp(point1->point, 0);
     for (uint32_t j = i + 1; j < mpoint->ngeoms; j++)
     {
       const LWPOINT *point2 = mpoint->geoms[j];
       if (! point2 || lwpoint_is_empty(point2))
         continue;
-      POINT2D p2;
-      lwpoint_getPoint2d_p(point2, &p2);
-      if (p1.x == p2.x && p1.y == p2.y)
+      const POINT2D *p2 = getPoint2d_cp(point2->point, 0);
+      if (p1->x == p2->x && p1->y == p2->y)
         return false;
     }
   }
@@ -4348,10 +4341,7 @@ relate_extract_points_iter(const LWGEOM *geom, POINT2D *result, int *count)
     return;
   if (geom->type == POINTTYPE)
   {
-    POINT4D p;
-    getPoint4d_p(((const LWPOINT *) geom)->point, 0, &p);
-    result[*count].x = p.x;
-    result[*count].y = p.y;
+    result[*count] = *getPoint2d_cp(((const LWPOINT *) geom)->point, 0);
     (*count)++;
     return;
   }

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -1467,12 +1467,11 @@ lw_distance_fraction(const LWGEOM *geom1, const LWGEOM *geom2, int mode,
       assert(geom1->type == LINETYPE);
       LWLINE *lwline = lwgeom_as_lwline(geom1);
       /* Initialize edge */
-      POINT4D a, b;
       GEOGRAPHIC_POINT proj;
-      getPoint4d_p(lwline->points, 0, &a);
-      getPoint4d_p(lwline->points, 1, &b);
-      geographic_point_init(a.x, a.y, &(e.start));
-      geographic_point_init(b.x, b.y, &(e.end));
+      const POINT2D *a = getPoint2d_cp(lwline->points, 0);
+      const POINT2D *b = getPoint2d_cp(lwline->points, 1);
+      geographic_point_init(a->x, a->y, &(e.start));
+      geographic_point_init(b->x, b->y, &(e.end));
       /* Get the spherical distance between point and edge */
       edge_distance_to_point(&e, &closest1, &proj);
       /* Compute distance from beginning of the segment to closest point */
@@ -1513,10 +1512,10 @@ lw_distance_fraction(const LWGEOM *geom1, const LWGEOM *geom2, int mode,
       {
         assert(geom1->type == LINETYPE);
         LWLINE *lwline = lwgeom_as_lwline(geom1);
-        POINT2D a, b, closest;
-        getPoint2d_p(lwline->points, 0, &a);
-        getPoint2d_p(lwline->points, 1, &b);
-        *fraction = closest_point2d_on_segment_ratio(&dl.p1, &a, &b, &closest);
+        POINT2D closest;
+        *fraction = closest_point2d_on_segment_ratio(&dl.p1,
+          getPoint2d_cp(lwline->points, 0), getPoint2d_cp(lwline->points, 1),
+          &closest);
       }
     }
   }

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -1425,12 +1425,12 @@ linear_pieces_geo(const MeosArray *pieces, const MeosArray *touches,
      * the weld leaves the line the shape it already had */
     if (pa->npoints >= 2)
     {
-      POINT2D u, v;
-      getPoint2d_p(pa, pa->npoints - 2, &u);
-      getPoint2d_p(pa, pa->npoints - 1, &v);
-      double cross = (v.x - u.x) * (q1.y - v.y) - (v.y - u.y) * (q1.x - v.x);
-      double scale = fmax(fabs(v.x - u.x) + fabs(v.y - u.y),
-        fabs(q1.x - v.x) + fabs(q1.y - v.y));
+      const POINT2D *u = getPoint2d_cp(pa, pa->npoints - 2);
+      const POINT2D *v = getPoint2d_cp(pa, pa->npoints - 1);
+      double cross = (v->x - u->x) * (q1.y - v->y) -
+        (v->y - u->y) * (q1.x - v->x);
+      double scale = fmax(fabs(v->x - u->x) + fabs(v->y - u->y),
+        fabs(q1.x - v->x) + fabs(q1.y - v->y));
       if (fabs(cross) <= MEOS_GEOM_TOLERANCE * fmax(scale, 1.0))
       {
         ptarray_remove_point(pa, pa->npoints - 1);
@@ -1739,16 +1739,15 @@ geo_clip_linear_geom(const GSERIALIZED *line, const GSERIALIZED *gs,
       continue;
     for (uint32_t i = 1; i < ln->points->npoints; i++)
     {
-      POINT2D pa, pb;
-      getPoint2d_p(ln->points, i - 1, &pa);
-      getPoint2d_p(ln->points, i, &pb);
+      const POINT2D *pa = getPoint2d_cp(ln->points, i - 1);
+      const POINT2D *pb = getPoint2d_cp(ln->points, i);
       Edge **sel = ctx->edge_ptrs;
       int seln = ctx->nedges;
       if (ctx->rtree)
       {
         STBox query;
-        stbox_set(true, false, false, ctx->srid, Min(pa.x, pb.x),
-          Max(pa.x, pb.x), Min(pa.y, pb.y), Max(pa.y, pb.y), 0, 0, NULL,
+        stbox_set(true, false, false, ctx->srid, Min(pa->x, pb->x),
+          Max(pa->x, pb->x), Min(pa->y, pb->y), Max(pa->y, pb->y), 0, 0, NULL,
           &query);
         int nc = rtree_search(ctx->rtree, INDEX_OVERLAPS, &query,
           rtree_results);
@@ -1758,10 +1757,10 @@ geo_clip_linear_geom(const GSERIALIZED *line, const GSERIALIZED *gs,
         sel = ctx->cand_edges; seln = nc;
       }
       intervals->count = 0;
-      intervals_from_points(&pa, &pb, sel, seln);
-      intervals_from_lines(&pa, &pb, sel, seln);
-      intervals_from_arcs(&pa, &pb, sel, seln);
-      intervals_from_polygons(&pa, &pb, sel, seln, ctx->edge_ptrs,
+      intervals_from_points(pa, pb, sel, seln);
+      intervals_from_lines(pa, pb, sel, seln);
+      intervals_from_arcs(pa, pb, sel, seln);
+      intervals_from_polygons(pa, pb, sel, seln, ctx->edge_ptrs,
         ctx->nedges, ctx->rtree, ctx->box.xmax);
 
       const Span *intervarr = intervals->elems;
@@ -1776,7 +1775,7 @@ geo_clip_linear_geom(const GSERIALIZED *line, const GSERIALIZED *gs,
         norm = spanarr_normalize(intervals->elems, count, ORDER, &count);
         intervarr = norm;
       }
-      segment_pieces(&pa, &pb, intervarr, count, inside, pieces, touches);
+      segment_pieces(pa, pb, intervarr, count, inside, pieces, touches);
       if (norm)
         pfree(norm);
     }

--- a/meos/src/h3/h3_geo.c
+++ b/meos/src/h3/h3_geo.c
@@ -366,10 +366,10 @@ h3_segment_cells(double lon1, double lat1, double lon2, double lat2,
 static void
 point_to_cells_into(const LWPOINT *lwp, int32 resolution, h3_buf *out)
 {
-  POINT4D p;
-  if (! lwpoint_getPoint4d_p(lwp, &p))
+  if (lwpoint_is_empty(lwp))
     return;
-  H3Index cell = h3_latlng_deg_to_cell(p.y, p.x, resolution);
+  const POINT2D *p = getPoint2d_cp(lwp->point, 0);
+  H3Index cell = h3_latlng_deg_to_cell(p->y, p->x, resolution);
   h3_buf_push(out, cell);
 }
 
@@ -408,11 +408,10 @@ linestring_to_cells_into(const LWLINE *line, int32 resolution, h3_buf *out)
 
   for (uint32_t i = 0; i + 1 < pa->npoints; i++)
   {
-    POINT4D p0, p1;
-    getPoint4d_p(pa, i,     &p0);
-    getPoint4d_p(pa, i + 1, &p1);
-    double dx = p1.x - p0.x;
-    double dy = p1.y - p0.y;
+    const POINT2D *p0 = getPoint2d_cp(pa, i);
+    const POINT2D *p1 = getPoint2d_cp(pa, i + 1);
+    double dx = p1->x - p0->x;
+    double dy = p1->y - p0->y;
     double seg_deg = sqrt(dx * dx + dy * dy);
     int nsamples = (int) ceil(seg_deg / step_deg);
     if (nsamples < 1)
@@ -420,8 +419,8 @@ linestring_to_cells_into(const LWLINE *line, int32 resolution, h3_buf *out)
     for (int s = 0; s <= nsamples; s++)
     {
       double t = (double) s / (double) nsamples;
-      double lat = p0.y + t * dy;
-      double lng = p0.x + t * dx;
+      double lat = p0->y + t * dy;
+      double lng = p0->x + t * dx;
       h3_buf_push_ring1(out, h3_latlng_deg_to_cell(lat, lng, resolution));
     }
   }
@@ -443,20 +442,18 @@ pointarray_to_geoloop(const POINTARRAY *pa, GeoLoop *loop)
    * the ring is closed (npoints with last == first). */
   if (n >= 2)
   {
-    POINT4D first, last;
-    getPoint4d_p(pa, 0,     &first);
-    getPoint4d_p(pa, n - 1, &last);
-    if (first.x == last.x && first.y == last.y)
+    const POINT2D *first = getPoint2d_cp(pa, 0);
+    const POINT2D *last = getPoint2d_cp(pa, n - 1);
+    if (first->x == last->x && first->y == last->y)
       n--;
   }
   loop->numVerts = (int) n;
   loop->verts    = palloc(sizeof(LatLng) * (size_t) (n > 0 ? n : 1));
   for (uint32_t i = 0; i < n; i++)
   {
-    POINT4D p;
-    getPoint4d_p(pa, i, &p);
-    loop->verts[i].lng = degsToRads(p.x);
-    loop->verts[i].lat = degsToRads(p.y);
+    const POINT2D *p = getPoint2d_cp(pa, i);
+    loop->verts[i].lng = degsToRads(p->x);
+    loop->verts[i].lat = degsToRads(p->y);
   }
 }
 

--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -361,22 +361,22 @@ rel_posesegm_interpolate(Pose *pose1_s, Pose *pose1_e, Pose *pose2_s,
  * of the closest feature between a fixed point and a rotating polygon edge
  */
 static double
-f_tpoint_poly(POINT4D p, POINT4D q, POINT4D r, Pose *poly_pose_s,
-  Pose *poly_pose_e, double ratio, bool solution_kind)
+f_tpoint_poly(const POINT2D *p, const POINT2D *q, const POINT2D *r,
+  Pose *poly_pose_s, Pose *poly_pose_e, double ratio, bool solution_kind)
 {
   double dx, dy, dtheta;
   double co, si, qx, qy, rx, ry;
   pose_interpolate_2d(poly_pose_s, poly_pose_e, ratio, &dx, &dy, &dtheta);
   co = cos(dtheta);
   si = sin(dtheta);
-  qx = q.x * co - q.y * si + dx;
-  qy = q.x * si + q.y * co + dy;
-  rx = r.x * co - r.y * si + dx;
-  ry = r.x * si + r.y * co + dy;
+  qx = q->x * co - q->y * si + dx;
+  qy = q->x * si + q->y * co + dy;
+  rx = r->x * co - r->y * si + dx;
+  ry = r->x * si + r->y * co + dy;
   if (solution_kind) /* MEOS_SOLVE_0 */
-    return (p.x - qx) * (rx - qx) + (p.y - qy) * (ry - qy);
+    return (p->x - qx) * (rx - qx) + (p->y - qy) * (ry - qy);
   else /* MEOS_SOLVE_1 */
-    return (p.x - rx) * (rx - qx) + (p.y - ry) * (ry - qy);
+    return (p->x - rx) * (rx - qx) + (p->y - ry) * (ry - qy);
 }
 
 /**
@@ -408,34 +408,36 @@ solve_s_tpoly_point(LWPOLY *poly, LWPOINT *point, Pose *poly_pose_s,
   Pose *poly_pose_e, uint32_t poly_v, double prev_result, bool solution_kind)
 {
   uint32_t n = poly->rings[0]->npoints - 1;
-  POINT4D p, q, r;
-  lwpoint_getPoint4d_p(point, &p);
-  getPoint4d_p(poly->rings[0], poly_v, &q);
-  getPoint4d_p(poly->rings[0], uint_mod_add(poly_v, 1, n), &r);
+  const POINT2D *p = getPoint2d_cp(point->point, 0);
+  const POINT2D *q = getPoint2d_cp(poly->rings[0], poly_v);
+  const POINT2D *r = getPoint2d_cp(poly->rings[0], uint_mod_add(poly_v, 1, n));
 
 /*  if (solution_kind)
     printf("s(t) = 0; p = (%lf, %lf), q = (%lf, %lf), r = (%lf, %lf), \npose_1 = (%lf, %lf, %lf), pose_2 = (%lf, %lf, %lf)\n",
-      p.x, p.y, q.x, q.y, r.x, r.y,
+      p->x, p->y, q->x, q->y, r->x, r->y,
       poly_pose_s->data[0], poly_pose_s->data[1], poly_pose_s->data[2],
       poly_pose_e->data[0], poly_pose_e->data[1], poly_pose_e->data[2]);
   else
     printf("s(t) = 1; p = (%lf, %lf), q = (%lf, %lf), r = (%lf, %lf), \npose_1 = (%lf, %lf, %lf), pose_2 = (%lf, %lf, %lf)\n",
-      p.x, p.y, q.x, q.y, r.x, r.y,
+      p->x, p->y, q->x, q->y, r->x, r->y,
       poly_pose_s->data[0], poly_pose_s->data[1], poly_pose_s->data[2],
       poly_pose_e->data[0], poly_pose_e->data[1], poly_pose_e->data[2]);
   fflush(stdout);*/
 
   if (fabs(poly_pose_s->data[2] - poly_pose_e->data[2]) < MEOS_EPSILON)
   {
-    apply_pose_point4d(&q, poly_pose_s);
-    apply_pose_point4d(&r, poly_pose_s);
+    POINT2D qp = *q, rp = *r;
+    apply_pose_point2d(&qp, poly_pose_s);
+    apply_pose_point2d(&rp, poly_pose_s);
     double result;
-    double discr = ((poly_pose_e->data[0] - poly_pose_s->data[0]) * (r.x - q.x)
-      + (poly_pose_e->data[1] - poly_pose_s->data[1]) * (r.y - q.y));
+    double discr = ((poly_pose_e->data[0] - poly_pose_s->data[0]) * (rp.x - qp.x)
+      + (poly_pose_e->data[1] - poly_pose_s->data[1]) * (rp.y - qp.y));
     if (solution_kind) /* MEOS_SOLVE_0 */
-      result = ((p.x - q.x) * (r.x - q.x) + (p.y - q.y) * (r.y - q.y)) / discr;
+      result = ((p->x - qp.x) * (rp.x - qp.x) + (p->y - qp.y) * (rp.y - qp.y)) /
+        discr;
     else /* MEOS_SOLVE_1 */
-      result = ((p.x - r.x) * (r.x - q.x) + (p.y - r.y) * (r.y - q.y)) / discr;
+      result = ((p->x - rp.x) * (rp.x - qp.x) + (p->y - rp.y) * (rp.y - qp.y)) /
+        discr;
     return transition_ratio(result, prev_result);
   }
 
@@ -888,9 +890,9 @@ dist2d_trgeoseq_point(const TSequence *seq, const GSERIALIZED *gs,
  * of the closest feature between a fixed polygon and a rotating one
  */
 static double
-f_tpoly_poly(POINT4D p, POINT4D q, POINT4D r, Pose *poly_pose_s,
-  Pose *poly_pose_e, Pose *poly2_pose_s, Pose *poly2_pose_e, double ratio,
-  bool solution_kind)
+f_tpoly_poly(const POINT2D *p, const POINT2D *q, const POINT2D *r,
+  Pose *poly_pose_s, Pose *poly_pose_e, Pose *poly2_pose_s, Pose *poly2_pose_e,
+  double ratio, bool solution_kind)
 {
   double dx, dy, dtheta;
   double co, si, qx, qy, rx, ry;
@@ -898,14 +900,14 @@ f_tpoly_poly(POINT4D p, POINT4D q, POINT4D r, Pose *poly_pose_s,
     ratio, &dx, &dy, &dtheta);
   co = cos(dtheta);
   si = sin(dtheta);
-  qx = q.x * co - q.y * si + dx;
-  qy = q.x * si + q.y * co + dy;
-  rx = r.x * co - r.y * si + dx;
-  ry = r.x * si + r.y * co + dy;
+  qx = q->x * co - q->y * si + dx;
+  qy = q->x * si + q->y * co + dy;
+  rx = r->x * co - r->y * si + dx;
+  ry = r->x * si + r->y * co + dy;
   if (solution_kind) /* MEOS_SOLVE_0 */
-    return (p.x - qx) * (rx - qx) + (p.y - qy) * (ry - qy);
+    return (p->x - qx) * (rx - qx) + (p->y - qy) * (ry - qy);
   else /* MEOS_SOLVE_1 */
-    return (p.x - rx) * (rx - qx) + (p.y - ry) * (ry - qy);
+    return (p->x - rx) * (rx - qx) + (p->y - ry) * (ry - qy);
 }
 
 /**
@@ -918,10 +920,10 @@ solve_s_tpoly_poly(LWPOLY *poly1, Pose *poly_pose_s, Pose *poly_pose_e,
   uint32_t poly2_v, double prev_result, bool solution_kind)
 {
   uint32_t n1 = poly1->rings[0]->npoints - 1;
-  POINT4D p, q, r;
-  getPoint4d_p(poly2->rings[0], poly2_v, &p);
-  getPoint4d_p(poly1->rings[0], poly1_v, &q);
-  getPoint4d_p(poly1->rings[0], uint_mod_add(poly1_v, 1, n1), &r);
+  const POINT2D *p = getPoint2d_cp(poly2->rings[0], poly2_v);
+  const POINT2D *q = getPoint2d_cp(poly1->rings[0], poly1_v);
+  const POINT2D *r = getPoint2d_cp(poly1->rings[0],
+    uint_mod_add(poly1_v, 1, n1));
 
   /* The closed-form shortcut assumes the second polygon is static; with both
    * polygons moving the relative motion is not a linear pose segment, so fall
@@ -929,17 +931,20 @@ solve_s_tpoly_poly(LWPOLY *poly1, Pose *poly_pose_s, Pose *poly_pose_e,
   if (! poly2_pose_s &&
       fabs(poly_pose_s->data[2] - poly_pose_e->data[2]) < MEOS_EPSILON)
   {
-    apply_pose_point4d(&q, poly_pose_s);
-    apply_pose_point4d(&r, poly_pose_s);
+    POINT2D qp = *q, rp = *r;
+    apply_pose_point2d(&qp, poly_pose_s);
+    apply_pose_point2d(&rp, poly_pose_s);
     double result;
-    double discr = (poly_pose_e->data[0] - poly_pose_s->data[0]) * (r.x - q.x)
-                 + (poly_pose_e->data[1] - poly_pose_s->data[1]) * (r.y - q.y);
+    double discr = (poly_pose_e->data[0] - poly_pose_s->data[0]) * (rp.x - qp.x)
+                 + (poly_pose_e->data[1] - poly_pose_s->data[1]) * (rp.y - qp.y);
     if (fabs(discr) < MEOS_EPSILON)
       return 2;
     if (solution_kind) /* MEOS_SOLVE_0 */
-      result = ((p.x - q.x) * (r.x - q.x) + (p.y - q.y) * (r.y - q.y)) / discr;
+      result = ((p->x - qp.x) * (rp.x - qp.x) + (p->y - qp.y) * (rp.y - qp.y)) /
+        discr;
     else /* MEOS_SOLVE_1 */
-      result = ((p.x - r.x) * (r.x - q.x) + (p.y - r.y) * (r.y - q.y)) / discr;
+      result = ((p->x - rp.x) * (rp.x - qp.x) + (p->y - rp.y) * (rp.y - qp.y)) /
+        discr;
     return transition_ratio(result, prev_result);
   }
 
@@ -989,9 +994,9 @@ solve_s_tpoly_poly(LWPOLY *poly1, Pose *poly_pose_s, Pose *poly_pose_e,
  * of the closest feature between a rotating polygon and a fixed one
  */
 static double
-f_poly_tpoly(POINT4D p, POINT4D q, POINT4D r, Pose *poly_pose_s,
-  Pose *poly_pose_e, Pose *poly2_pose_s, Pose *poly2_pose_e, double ratio,
-  bool solution_kind)
+f_poly_tpoly(const POINT2D *p, const POINT2D *q, const POINT2D *r,
+  Pose *poly_pose_s, Pose *poly_pose_e, Pose *poly2_pose_s, Pose *poly2_pose_e,
+  double ratio, bool solution_kind)
 {
   double dx, dy, dtheta;
   double co, si, px, py;
@@ -999,12 +1004,12 @@ f_poly_tpoly(POINT4D p, POINT4D q, POINT4D r, Pose *poly_pose_s,
     ratio, &dx, &dy, &dtheta);
   co = cos(dtheta);
   si = sin(dtheta);
-  px = p.x * co - p.y * si + dx;
-  py = p.x * si + p.y * co + dy;
+  px = p->x * co - p->y * si + dx;
+  py = p->x * si + p->y * co + dy;
   if (solution_kind) /* MEOS_SOLVE_0 */
-    return (px - q.x) * (r.x - q.x) + (py - q.y) * (r.y - q.y);
+    return (px - q->x) * (r->x - q->x) + (py - q->y) * (r->y - q->y);
   else /* MEOS_SOLVE_1 */
-    return (px - r.x) * (r.x - q.x) + (py - r.y) * (r.y - q.y);
+    return (px - r->x) * (r->x - q->x) + (py - r->y) * (r->y - q->y);
 }
 
 /**
@@ -1017,10 +1022,10 @@ solve_s_poly_tpoly(LWPOLY *poly1, LWPOLY *poly2, Pose *poly_pose_s,
   uint32_t poly2_v, double prev_result, bool solution_kind)
 {
   uint32_t n1 = poly1->rings[0]->npoints - 1;
-  POINT4D p, q, r;
-  getPoint4d_p(poly2->rings[0], poly2_v, &p);
-  getPoint4d_p(poly1->rings[0], poly1_v, &q);
-  getPoint4d_p(poly1->rings[0], uint_mod_add(poly1_v, 1, n1), &r);
+  const POINT2D *p = getPoint2d_cp(poly2->rings[0], poly2_v);
+  const POINT2D *q = getPoint2d_cp(poly1->rings[0], poly1_v);
+  const POINT2D *r = getPoint2d_cp(poly1->rings[0],
+    uint_mod_add(poly1_v, 1, n1));
 
   /* The closed-form shortcut assumes the second polygon is static; with both
    * polygons moving the relative motion is not a linear pose segment, so fall
@@ -1028,16 +1033,19 @@ solve_s_poly_tpoly(LWPOLY *poly1, LWPOLY *poly2, Pose *poly_pose_s,
   if (! poly2_pose_s &&
       fabs(poly_pose_s->data[2] - poly_pose_e->data[2]) < MEOS_EPSILON)
   {
-    apply_pose_point4d(&p, poly_pose_s);
+    POINT2D pp = *p;
+    apply_pose_point2d(&pp, poly_pose_s);
     double result;
-    double discr = - (poly_pose_e->data[0] - poly_pose_s->data[0]) * (r.x - q.x)
-                   - (poly_pose_e->data[1] - poly_pose_s->data[1]) * (r.y - q.y);
+    double discr = - (poly_pose_e->data[0] - poly_pose_s->data[0]) * (r->x - q->x)
+                   - (poly_pose_e->data[1] - poly_pose_s->data[1]) * (r->y - q->y);
     if (fabs(discr) < MEOS_EPSILON)
       return 2;
     if (solution_kind) /* MEOS_SOLVE_0 */
-      result = ((p.x - q.x) * (r.x - q.x) + (p.y - q.y) * (r.y - q.y)) / discr;
+      result = ((pp.x - q->x) * (r->x - q->x) + (pp.y - q->y) * (r->y - q->y)) /
+        discr;
     else /* MEOS_SOLVE_1 */
-      result = ((p.x - r.x) * (r.x - q.x) + (p.y - r.y) * (r.y - q.y)) / discr;
+      result = ((pp.x - r->x) * (r->x - q->x) + (pp.y - r->y) * (r->y - q->y)) /
+        discr;
     return transition_ratio(result, prev_result);
   }
 
@@ -1179,22 +1187,23 @@ f_parallel_edges_tpoly_poly(LWPOLY *poly1, Pose *poly_pose_s, Pose *poly_pose_e,
 {
   uint32_t n1 = poly1->rings[0]->npoints - 1;
   uint32_t n2 = poly2->rings[0]->npoints - 1;
-  POINT4D ps, pe, qs, qe;
-  getPoint4d_p(poly1->rings[0], poly1_v, &qs);
-  getPoint4d_p(poly1->rings[0], uint_mod_add(poly1_v, 1, n1), &qe);
-  getPoint4d_p(poly2->rings[0], poly2_v, &ps);
-  getPoint4d_p(poly2->rings[0], uint_mod_add(poly2_v, 1, n2), &pe);
+  const POINT2D *qs = getPoint2d_cp(poly1->rings[0], poly1_v);
+  const POINT2D *qe = getPoint2d_cp(poly1->rings[0],
+    uint_mod_add(poly1_v, 1, n1));
+  const POINT2D *ps = getPoint2d_cp(poly2->rings[0], poly2_v);
+  const POINT2D *pe = getPoint2d_cp(poly2->rings[0],
+    uint_mod_add(poly2_v, 1, n2));
   double dx, dy, dtheta;
   double co, si, qsx, qsy, qex, qey;
   rel_pose_interpolate_2d(poly_pose_s, poly_pose_e, poly2_pose_s, poly2_pose_e,
     ratio, &dx, &dy, &dtheta);
   co = cos(dtheta);
   si = sin(dtheta);
-  qsx = qs.x * co - qs.y * si + dx;
-  qsy = qs.x * si + qs.y * co + dy;
-  qex = qe.x * co - qe.y * si + dx;
-  qey = qe.x * si + qe.y * co + dy;
-  return (pe.x - ps.x) * (qey - qsy) - (pe.y - ps.y) * (qex - qsx);
+  qsx = qs->x * co - qs->y * si + dx;
+  qsy = qs->x * si + qs->y * co + dy;
+  qex = qe->x * co - qe->y * si + dx;
+  qey = qe->x * si + qe->y * co + dy;
+  return (pe->x - ps->x) * (qey - qsy) - (pe->y - ps->y) * (qex - qsx);
 }
 
 /**
@@ -1333,19 +1342,18 @@ vertex_edge_tpoly_poly(LWPOLY *poly1, Pose *pose_start, Pose *pose_end,
     /* Determine how to update closest feature */
     uint32_t n1 = poly1->rings[0]->npoints - 1;
     uint32_t n2 = poly2->rings[0]->npoints - 1;
-    POINT4D ps, pe, qs, qe;
-    getPoint4d_p(poly1->rings[0], i1, &qs);
-    getPoint4d_p(poly1->rings[0], uint_mod_add(i1, 1, n1), &qe);
-    getPoint4d_p(poly2->rings[0], i2, &ps);
-    getPoint4d_p(poly2->rings[0], uint_mod_add(i2, 1, n2), &pe);
+    const POINT2D *ps = getPoint2d_cp(poly2->rings[0], i2);
+    const POINT2D *pe = getPoint2d_cp(poly2->rings[0], uint_mod_add(i2, 1, n2));
+    POINT2D qs = *getPoint2d_cp(poly1->rings[0], i1);
+    POINT2D qe = *getPoint2d_cp(poly1->rings[0], uint_mod_add(i1, 1, n1));
     Pose *pose = rel_posesegm_interpolate(pose_start, pose_end, pose2_start,
       pose2_end, ratio_3);
-    apply_pose_point4d(&qs, pose);
-    apply_pose_point4d(&qe, pose);
+    apply_pose_point2d(&qs, pose);
+    apply_pose_point2d(&qe, pose);
     pfree(pose);
     /* TODO: check if we assume that ccw1 == ccw2 here or not */
-    double s1 = compute_s(qe, ps, pe);
-    double s2 = compute_s(ps, qs, qe);
+    double s1 = compute_s(&qe, ps, pe);
+    double s2 = compute_s(ps, &qs, &qe);
     // printf("C: %lf, %lf\n", s1, s2);
     // fflush(stdout);
     if (0 < s1 && s1 < 1)
@@ -1386,19 +1394,18 @@ vertex_edge_tpoly_poly(LWPOLY *poly1, Pose *pose_start, Pose *pose_end,
     /* Determine how to update closest feature */
     uint32_t n1 = poly1->rings[0]->npoints - 1;
     uint32_t n2 = poly2->rings[0]->npoints - 1;
-    POINT4D ps, pe, qs, qe;
-    getPoint4d_p(poly1->rings[0], uint_mod_sub(i1, 1, n1), &qs);
-    getPoint4d_p(poly1->rings[0], i1, &qe);
-    getPoint4d_p(poly2->rings[0], i2, &ps);
-    getPoint4d_p(poly2->rings[0], uint_mod_add(i2, 1, n2), &pe);
+    const POINT2D *ps = getPoint2d_cp(poly2->rings[0], i2);
+    const POINT2D *pe = getPoint2d_cp(poly2->rings[0], uint_mod_add(i2, 1, n2));
+    POINT2D qs = *getPoint2d_cp(poly1->rings[0], uint_mod_sub(i1, 1, n1));
+    POINT2D qe = *getPoint2d_cp(poly1->rings[0], i1);
     Pose *pose = rel_posesegm_interpolate(pose_start, pose_end, pose2_start,
       pose2_end, ratio_4);
-    apply_pose_point4d(&qs, pose);
-    apply_pose_point4d(&qe, pose);
+    apply_pose_point2d(&qs, pose);
+    apply_pose_point2d(&qe, pose);
     pfree(pose);
     /* TODO: check if we assume that ccw1 == ccw2 here or not */
-    double s1 = compute_s(qs, ps, pe);
-    double s2 = compute_s(pe, qs, qe);
+    double s1 = compute_s(&qs, ps, pe);
+    double s2 = compute_s(pe, &qs, &qe);
     // printf("D: %lf, %lf\n", s1, s2);
     // fflush(stdout);
     if (0 < s1 && s1 < 1)
@@ -1499,19 +1506,18 @@ edge_vertex_tpoly_poly(LWPOLY *poly1, Pose *pose_start, Pose *pose_end,
     /* Determine how to update closest feature */
     uint32_t n1 = poly1->rings[0]->npoints - 1;
     uint32_t n2 = poly2->rings[0]->npoints - 1;
-    POINT4D ps, pe, qs, qe;
-    getPoint4d_p(poly1->rings[0], i1, &qs);
-    getPoint4d_p(poly1->rings[0], uint_mod_add(i1, 1, n1), &qe);
-    getPoint4d_p(poly2->rings[0], i2, &ps);
-    getPoint4d_p(poly2->rings[0], uint_mod_add(i2, 1, n2), &pe);
+    const POINT2D *ps = getPoint2d_cp(poly2->rings[0], i2);
+    const POINT2D *pe = getPoint2d_cp(poly2->rings[0], uint_mod_add(i2, 1, n2));
+    POINT2D qs = *getPoint2d_cp(poly1->rings[0], i1);
+    POINT2D qe = *getPoint2d_cp(poly1->rings[0], uint_mod_add(i1, 1, n1));
     Pose *pose = rel_posesegm_interpolate(pose_start, pose_end, pose2_start,
       pose2_end, ratio_3);
-    apply_pose_point4d(&qs, pose);
-    apply_pose_point4d(&qe, pose);
+    apply_pose_point2d(&qs, pose);
+    apply_pose_point2d(&qe, pose);
     pfree(pose);
     /* TODO: check if we assume that ccw1 == ccw2 here or not */
-    double s1 = compute_s(pe, qs, qe);
-    double s2 = compute_s(qs, ps, pe);
+    double s1 = compute_s(pe, &qs, &qe);
+    double s2 = compute_s(&qs, ps, pe);
     // printf("A: %lf, %lf\n", s1, s2);
     // fflush(stdout);
     if (0 < s1 && s1 < 1)
@@ -1552,19 +1558,18 @@ edge_vertex_tpoly_poly(LWPOLY *poly1, Pose *pose_start, Pose *pose_end,
     /* Determine how to update closest feature */
     uint32_t n1 = poly1->rings[0]->npoints - 1;
     uint32_t n2 = poly2->rings[0]->npoints - 1;
-    POINT4D ps, pe, qs, qe;
-    getPoint4d_p(poly1->rings[0], i1, &qs);
-    getPoint4d_p(poly1->rings[0], uint_mod_add(i1, 1, n1), &qe);
-    getPoint4d_p(poly2->rings[0], uint_mod_sub(i2, 1, n2), &ps);
-    getPoint4d_p(poly2->rings[0], i2, &pe);
+    const POINT2D *ps = getPoint2d_cp(poly2->rings[0], uint_mod_sub(i2, 1, n2));
+    const POINT2D *pe = getPoint2d_cp(poly2->rings[0], i2);
+    POINT2D qs = *getPoint2d_cp(poly1->rings[0], i1);
+    POINT2D qe = *getPoint2d_cp(poly1->rings[0], uint_mod_add(i1, 1, n1));
     Pose *pose = rel_posesegm_interpolate(pose_start, pose_end, pose2_start,
       pose2_end, ratio_4);
-    apply_pose_point4d(&qs, pose);
-    apply_pose_point4d(&qe, pose);
+    apply_pose_point2d(&qs, pose);
+    apply_pose_point2d(&qe, pose);
     pfree(pose);
     /* TODO: check if we assume that ccw1 == ccw2 here or not */
-    double s1 = compute_s(ps, qs, qe);
-    double s2 = compute_s(qe, ps, pe);
+    double s1 = compute_s(ps, &qs, &qe);
+    double s2 = compute_s(&qe, ps, pe);
     // printf("B: %lf, %lf\n", s1, s2);
     // fflush(stdout);
     if (0 < s1 && s1 < 1)
@@ -2460,9 +2465,9 @@ trgeoinst_translate_by_tpoint(const TInstant *pinst, const TInstant *qinst,
   const GSERIALIZED *ref_gs)
 {
   const Pose *pose = DatumGetPoseP(tinstant_value_p(pinst));
-  POINT4D pt;
-  datum_point4d(tinstant_value_p(qinst), &pt);
-  Pose *tpose = pose_make_2d(pose->data[0] - pt.x, pose->data[1] - pt.y,
+  const POINT2D *pt = GSERIALIZED_POINT2D_P(
+    DatumGetGserializedP(tinstant_value_p(qinst)));
+  Pose *tpose = pose_make_2d(pose->data[0] - pt->x, pose->data[1] - pt->y,
     pose->data[2], MEOS_FLAGS_GET_GEODETIC(pose->flags), pose_srid(pose));
   TInstant *result = trgeometryinst_make(ref_gs, tpose, pinst->t);
   pfree(tpose);
@@ -2681,14 +2686,14 @@ nai_trgeometry_tpoint(const Temporal *temp1, const Temporal *temp2)
   Temporal *dist = tdistance_trgeometry_tpoint(temp1, temp2);
   if (dist != NULL)
   {
-    /* temporal_min_instant returns a copy that must be freed */
-    TInstant *min = temporal_min_instant(dist);
+    /* The instant is read in place, dist being freed only after it */
+    const TInstant *min = temporal_min_inst_p(dist);
     /* The closest point may be at an exclusive bound */
     Datum value;
     temporal_value_at_timestamptz(temp1, min->t, false, &value);
     result = trgeometryinst_make(trgeo_geom_p(temp1), DatumGetPoseP(value),
       min->t);
-    pfree(dist); pfree(min); pfree(DatumGetPointer(value));
+    pfree(dist); pfree(DatumGetPointer(value));
   }
   return result;
 }
@@ -2711,14 +2716,14 @@ nai_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)
   Temporal *dist = tdistance_trgeometry_trgeometry(temp1, temp2);
   if (dist != NULL)
   {
-    /* temporal_min_instant returns a copy that must be freed */
-    TInstant *min = temporal_min_instant(dist);
+    /* The instant is read in place, dist being freed only after it */
+    const TInstant *min = temporal_min_inst_p(dist);
     /* The closest point may be at an exclusive bound. */
     Datum value;
     temporal_value_at_timestamptz(temp1, min->t, false, &value);
     result = trgeometryinst_make(trgeo_geom_p(temp1), DatumGetPoseP(value),
       min->t);
-    pfree(dist); pfree(min); pfree(DatumGetPointer(value));
+    pfree(dist); pfree(DatumGetPointer(value));
   }
   return result;
 }

--- a/meos/src/rgeo/trgeo_vclip.c
+++ b/meos/src/rgeo/trgeo_vclip.c
@@ -66,7 +66,7 @@
  * @brief Apply a pose to a point, that is rotate it and then translate it
  */
 void
-apply_pose_point4d(POINT4D *p, const Pose *pose)
+apply_pose_point2d(POINT2D *p, const Pose *pose)
 {
   double c = cos(pose->data[2]);
   double s = sin(pose->data[2]);
@@ -86,9 +86,9 @@ apply_pose_point4d(POINT4D *p, const Pose *pose)
  * angle < 0: P is on the left of l
  */
 static inline double
-compute_angle(POINT4D p, POINT4D vs, POINT4D ve)
+compute_angle(const POINT2D *p, const POINT2D *vs, const POINT2D *ve)
 {
-  return (p.x - vs.x) * (ve.y - vs.y) - (p.y - vs.y) * (ve.x - vs.x);
+  return (p->x - vs->x) * (ve->y - vs->y) - (p->y - vs->y) * (ve->x - vs->x);
 }
 
 /**
@@ -99,11 +99,12 @@ compute_angle(POINT4D p, POINT4D vs, POINT4D ve)
  * between vs and ve. (0 <= compute_s(p, vs, ve) <= 1)
  */
 static inline double
-compute_dist2(POINT4D p, POINT4D vs, POINT4D ve)
+compute_dist2(const POINT2D *p, const POINT2D *vs, const POINT2D *ve)
 {
   double s = compute_s(p, vs, ve);
-  return (p.x - vs.x - (ve.x - vs.x) * s) * (p.x - vs.x - (ve.x - vs.x) * s) +
-    (p.y - vs.y - (ve.y - vs.y) * s) * (p.y - vs.y - (ve.y - vs.y) * s);
+  return
+    (p->x - vs->x - (ve->x - vs->x) * s) * (p->x - vs->x - (ve->x - vs->x) * s) +
+    (p->y - vs->y - (ve->y - vs->y) * s) * (p->y - vs->y - (ve->y - vs->y) * s);
 }
 
 /**
@@ -111,17 +112,17 @@ compute_dist2(POINT4D p, POINT4D vs, POINT4D ve)
  * projection that falls outside it
  */
 static inline double
-compute_dist2_safe(POINT4D p, POINT4D vs, POINT4D ve)
+compute_dist2_safe(const POINT2D *p, const POINT2D *vs, const POINT2D *ve)
 {
   double s = compute_s(p, vs, ve);
   if (s <= 0)
-    return (p.x - vs.x) * (p.x - vs.x) + (p.y - vs.y) * (p.y - vs.y);
+    return (p->x - vs->x) * (p->x - vs->x) + (p->y - vs->y) * (p->y - vs->y);
   else if (s >= 1)
-    return (p.x - ve.x) * (p.x - ve.x) + (p.y - ve.y) * (p.y - ve.y);
+    return (p->x - ve->x) * (p->x - ve->x) + (p->y - ve->y) * (p->y - ve->y);
   else
     return
-      (p.x - vs.x - (ve.x - vs.x) * s) * (p.x - vs.x - (ve.x - vs.x) * s) +
-      (p.y - vs.y - (ve.y - vs.y) * s) * (p.y - vs.y - (ve.y - vs.y) * s);
+      (p->x - vs->x - (ve->x - vs->x) * s) * (p->x - vs->x - (ve->x - vs->x) * s) +
+      (p->y - vs->y - (ve->y - vs->y) * s) * (p->y - vs->y - (ve->y - vs->y) * s);
 }
 
 /**
@@ -131,11 +132,8 @@ compute_dist2_safe(POINT4D p, POINT4D vs, POINT4D ve)
 static bool
 poly_is_ccw(const LWPOLY *poly)
 {
-  POINT4D v1, v2, v3;
-  getPoint4d_p(poly->rings[0], 0, &v1);
-  getPoint4d_p(poly->rings[0], 1, &v2);
-  getPoint4d_p(poly->rings[0], 2, &v3);
-  return compute_angle(v1, v2, v3) < 0;
+  return compute_angle(getPoint2d_cp(poly->rings[0], 0),
+    getPoint2d_cp(poly->rings[0], 1), getPoint2d_cp(poly->rings[0], 2)) < 0;
 }
 
 /**
@@ -143,34 +141,34 @@ poly_is_ccw(const LWPOLY *poly)
  * neighbouring vertex while one stands closer
  */
 static int
-vertex_vertex_tpoly_point(const LWPOLY *poly, POINT4D point,
+vertex_vertex_tpoly_point(const LWPOLY *poly, const POINT2D *point,
   const Pose *pose, uint32_t *poly_feature)
 {
   double s_next, s_prev;
-  POINT4D v, v_prev, v_next;
+  POINT2D v, v_prev, v_next;
   uint32_t n = poly->rings[0]->npoints - 1;
   uint32_t i = *poly_feature / 2;
 
   /* Get endpoints of previous and next edge */
-  getPoint4d_p(poly->rings[0], uint_mod_sub(i, 1, n), &v_prev);
-  getPoint4d_p(poly->rings[0], i, &v);
-  getPoint4d_p(poly->rings[0], uint_mod_add(i, 1, n), &v_next);
+  v_prev = *getPoint2d_cp(poly->rings[0], uint_mod_sub(i, 1, n));
+  v = *getPoint2d_cp(poly->rings[0], i);
+  v_next = *getPoint2d_cp(poly->rings[0], uint_mod_add(i, 1, n));
   if (pose)
   {
-    apply_pose_point4d(&v_prev, pose);
-    apply_pose_point4d(&v, pose);
-    apply_pose_point4d(&v_next, pose);
+    apply_pose_point2d(&v_prev, pose);
+    apply_pose_point2d(&v, pose);
+    apply_pose_point2d(&v_next, pose);
   }
 
   /* Check if the point is in v's Voronoi region */
-  s_prev = compute_s(point, v_prev, v);
+  s_prev = compute_s(point, &v_prev, &v);
   if (s_prev < 1)
   {
     /* Go to the previous edge */
     *poly_feature = uint_mod_sub(*poly_feature, 1, 2*n);
     return MEOS_CONTINUE;
   }
-  s_next = compute_s(point, v, v_next);
+  s_next = compute_s(point, &v, &v_next);
   if (s_next > 0)
   {
     /* Go to the next edge */
@@ -190,25 +188,25 @@ vertex_vertex_tpoly_point(const LWPOLY *poly, POINT4D point,
  * neighbouring feature while one stands closer
  */
 static int
-edge_vertex_tpoly_point(const LWPOLY *poly, POINT4D point,
+edge_vertex_tpoly_point(const LWPOLY *poly, const POINT2D *point,
   bool ccw_poly, const Pose *pose, uint32_t *poly_feature)
 {
   double s, angle;
-  POINT4D v_start, v_end;
+  POINT2D v_start, v_end;
   uint32_t n = poly->rings[0]->npoints - 1;
   uint32_t i = *poly_feature / 2;
 
   /* Get edge endpoints */
-  getPoint4d_p(poly->rings[0], i, &v_start);
-  getPoint4d_p(poly->rings[0], uint_mod_add(i, 1, n), &v_end);
+  v_start = *getPoint2d_cp(poly->rings[0], i);
+  v_end = *getPoint2d_cp(poly->rings[0], uint_mod_add(i, 1, n));
   if (pose)
   {
-    apply_pose_point4d(&v_start, pose);
-    apply_pose_point4d(&v_end, pose);
+    apply_pose_point2d(&v_start, pose);
+    apply_pose_point2d(&v_end, pose);
   }
 
   /* Check if the point is in the edge's Voronoi region */
-  s = compute_s(point, v_start, v_end);
+  s = compute_s(point, &v_start, &v_end);
   if (s < 0)
   {
     /* Go to the start vertex */
@@ -223,28 +221,28 @@ edge_vertex_tpoly_point(const LWPOLY *poly, POINT4D point,
   }
 
   /* Check for local minimum */
-  angle = compute_angle(point, v_start, v_end);
+  angle = compute_angle(point, &v_start, &v_end);
   if ((ccw_poly && angle < 0)
     || (!ccw_poly && angle > 0))
   {
     /* Found local minimum */
     double dmax = -1;
-    getPoint4d_p(poly->rings[0], 0, &v_start);
+    v_start = *getPoint2d_cp(poly->rings[0], 0);
     if (pose)
-      apply_pose_point4d(&v_start, pose);
+      apply_pose_point2d(&v_start, pose);
     for (i = 0; i < n; ++i)
     {
       /* Find edge with the largest positive distance
          to the given point */
       double distance = -1;
-      getPoint4d_p(poly->rings[0], i + 1, &v_end);
+      v_end = *getPoint2d_cp(poly->rings[0], i + 1);
       if (pose)
-        apply_pose_point4d(&v_end, pose);
-      angle = compute_angle(point, v_start, v_end);
+        apply_pose_point2d(&v_end, pose);
+      angle = compute_angle(point, &v_start, &v_end);
       if ((ccw_poly && angle > 0)
         || (!ccw_poly && angle < 0))
       {
-        distance = compute_dist2(point, v_start, v_end);
+        distance = compute_dist2(point, &v_start, &v_end);
         if (distance > dmax)
         {
           dmax = distance;
@@ -275,8 +273,7 @@ v_clip_tpoly_point(const LWPOLY *poly, const LWPOINT *point,
   int result;
   int loop = 0;
   bool ccw_poly = poly_is_ccw(poly);
-  POINT4D pt;
-  lwpoint_getPoint4d_p(point, &pt);
+  const POINT2D *pt = getPoint2d_cp(point->point, 0);
 
   do
   {
@@ -307,25 +304,25 @@ v_clip_tpoly_point(const LWPOLY *poly, const LWPOINT *point,
     /* compute the distance */
     if (*poly_feature % 2 == 0)
     {
-      POINT4D v;
+      POINT2D v;
       uint32_t i = *poly_feature / 2;
-      getPoint4d_p(poly->rings[0], i, &v);
+      v = *getPoint2d_cp(poly->rings[0], i);
       if (pose)
-        apply_pose_point4d(&v, pose);
-      *dist = sqrt((pt.x - v.x) * (pt.x - v.x) + (pt.y - v.y) * (pt.y - v.y));
+        apply_pose_point2d(&v, pose);
+      *dist = sqrt((pt->x - v.x) * (pt->x - v.x) + (pt->y - v.y) * (pt->y - v.y));
     }
     else
     {
-      POINT4D v_start, v_end;
+      POINT2D v_start, v_end;
       uint32_t i = *poly_feature / 2;
-      getPoint4d_p(poly->rings[0], i, &v_start);
-      getPoint4d_p(poly->rings[0], i + 1, &v_end);
+      v_start = *getPoint2d_cp(poly->rings[0], i);
+      v_end = *getPoint2d_cp(poly->rings[0], i + 1);
       if (pose)
       {
-        apply_pose_point4d(&v_start, pose);
-        apply_pose_point4d(&v_end, pose);
+        apply_pose_point2d(&v_start, pose);
+        apply_pose_point2d(&v_end, pose);
       }
-      *dist = sqrt(compute_dist2(pt, v_start, v_end));
+      *dist = sqrt(compute_dist2(pt, &v_start, &v_end));
     }
   }
   return MEOS_DISJOINT;
@@ -341,7 +338,7 @@ vertex_vertex_tpoly_tpoly(const LWPOLY *poly1, const LWPOLY *poly2,
   uint32_t *poly2_feature)
 {
   double s1_next, s1_prev, s2_prev, s2_next;
-  POINT4D v1, v1_prev, v1_next, v2, v2_prev, v2_next;
+  POINT2D v1, v1_prev, v1_next, v2, v2_prev, v2_next;
   uint32_t n1 = poly1->rings[0]->npoints - 1;
   uint32_t n2 = poly2->rings[0]->npoints - 1;
   uint32_t i1 = *poly1_feature / 2;
@@ -349,35 +346,35 @@ vertex_vertex_tpoly_tpoly(const LWPOLY *poly1, const LWPOLY *poly2,
 
   /* Get endpoints of previous and next edges */
   /* poly1 */
-  getPoint4d_p(poly1->rings[0], uint_mod_sub(i1, 1, n1), &v1_prev);
-  getPoint4d_p(poly1->rings[0], i1, &v1);
-  getPoint4d_p(poly1->rings[0], uint_mod_add(i1, 1, n1), &v1_next);
+  v1_prev = *getPoint2d_cp(poly1->rings[0], uint_mod_sub(i1, 1, n1));
+  v1 = *getPoint2d_cp(poly1->rings[0], i1);
+  v1_next = *getPoint2d_cp(poly1->rings[0], uint_mod_add(i1, 1, n1));
   if (pose1)
   {
-    apply_pose_point4d(&v1_prev, pose1);
-    apply_pose_point4d(&v1, pose1);
-    apply_pose_point4d(&v1_next, pose1);
+    apply_pose_point2d(&v1_prev, pose1);
+    apply_pose_point2d(&v1, pose1);
+    apply_pose_point2d(&v1_next, pose1);
   }
   /* poly2 */
-  getPoint4d_p(poly2->rings[0], uint_mod_sub(i2, 1, n2), &v2_prev);
-  getPoint4d_p(poly2->rings[0], i2, &v2);
-  getPoint4d_p(poly2->rings[0], uint_mod_add(i2, 1, n2), &v2_next);
+  v2_prev = *getPoint2d_cp(poly2->rings[0], uint_mod_sub(i2, 1, n2));
+  v2 = *getPoint2d_cp(poly2->rings[0], i2);
+  v2_next = *getPoint2d_cp(poly2->rings[0], uint_mod_add(i2, 1, n2));
   if (pose2)
   {
-    apply_pose_point4d(&v2_prev, pose2);
-    apply_pose_point4d(&v2, pose2);
-    apply_pose_point4d(&v2_next, pose2);
+    apply_pose_point2d(&v2_prev, pose2);
+    apply_pose_point2d(&v2, pose2);
+    apply_pose_point2d(&v2_next, pose2);
   }
 
   /* Check if v2 is in v1's Voronoi region */
-  s1_prev = compute_s(v2, v1_prev, v1);
+  s1_prev = compute_s(&v2, &v1_prev, &v1);
   if (s1_prev + MEOS_EPSILON < 1)
   {
     /* Go to the previous edge */
     *poly1_feature = uint_mod_sub(*poly1_feature, 1, 2*n1);
     return MEOS_CONTINUE;
   }
-  s1_next = compute_s(v2, v1, v1_next);
+  s1_next = compute_s(&v2, &v1, &v1_next);
   if (s1_next - MEOS_EPSILON > 0)
   {
     /* Go to the next edge */
@@ -385,14 +382,14 @@ vertex_vertex_tpoly_tpoly(const LWPOLY *poly1, const LWPOLY *poly2,
     return MEOS_CONTINUE;
   }
   /* Check if v1 is in v2's Voronoi region */
-  s2_prev = compute_s(v1, v2_prev, v2);
+  s2_prev = compute_s(&v1, &v2_prev, &v2);
   if (s2_prev + MEOS_EPSILON < 1)
   {
     /* Go to the previous edge */
     *poly2_feature = uint_mod_sub(*poly2_feature, 1, 2*n2);
     return MEOS_CONTINUE;
   }
-  s2_next = compute_s(v1, v2, v2_next);
+  s2_next = compute_s(&v1, &v2, &v2_next);
   if (s2_next - MEOS_EPSILON > 0)
   {
     /* Go to the next edge */
@@ -418,33 +415,33 @@ edge_vertex_tpoly_tpoly(const LWPOLY *poly1, const LWPOLY *poly2,
   uint32_t *poly1_feature, uint32_t *poly2_feature)
 {
   double s1, angle1, s2_prev, s2_next;
-  POINT4D v1, v1_start, v1_end, v2, v2_prev, v2_next;
+  POINT2D v1, v1_start, v1_end, v2, v2_prev, v2_next;
   uint32_t n1 = poly1->rings[0]->npoints - 1;
   uint32_t n2 = poly2->rings[0]->npoints - 1;
   uint32_t i1 = *poly1_feature / 2;
   uint32_t i2 = *poly2_feature / 2;
 
   /* Get edge endpoints of edge of poly1 */
-  getPoint4d_p(poly1->rings[0], i1, &v1_start);
-  getPoint4d_p(poly1->rings[0], uint_mod_add(i1, 1, n1), &v1_end);
+  v1_start = *getPoint2d_cp(poly1->rings[0], i1);
+  v1_end = *getPoint2d_cp(poly1->rings[0], uint_mod_add(i1, 1, n1));
   if (pose1)
   {
-    apply_pose_point4d(&v1_start, pose1);
-    apply_pose_point4d(&v1_end, pose1);
+    apply_pose_point2d(&v1_start, pose1);
+    apply_pose_point2d(&v1_end, pose1);
   }
   /* Get endpoints of previous and next edges of poly2 */
-  getPoint4d_p(poly2->rings[0], uint_mod_sub(i2, 1, n2), &v2_prev);
-  getPoint4d_p(poly2->rings[0], i2, &v2);
-  getPoint4d_p(poly2->rings[0], uint_mod_add(i2, 1, n2), &v2_next);
+  v2_prev = *getPoint2d_cp(poly2->rings[0], uint_mod_sub(i2, 1, n2));
+  v2 = *getPoint2d_cp(poly2->rings[0], i2);
+  v2_next = *getPoint2d_cp(poly2->rings[0], uint_mod_add(i2, 1, n2));
   if (pose2)
   {
-    apply_pose_point4d(&v2_prev, pose2);
-    apply_pose_point4d(&v2, pose2);
-    apply_pose_point4d(&v2_next, pose2);
+    apply_pose_point2d(&v2_prev, pose2);
+    apply_pose_point2d(&v2, pose2);
+    apply_pose_point2d(&v2_next, pose2);
   }
 
   /* Check if v2 is in the Voronoi region of the edge of poly1 */
-  s1 = compute_s(v2, v1_start, v1_end);
+  s1 = compute_s(&v2, &v1_start, &v1_end);
   if (s1 + MEOS_EPSILON < 0)
   {
     /* Go to the start vertex */
@@ -459,27 +456,27 @@ edge_vertex_tpoly_tpoly(const LWPOLY *poly1, const LWPOLY *poly2,
   }
 
   /* Check for local minimum */
-  angle1 = compute_angle(v2, v1_start, v1_end);
+  angle1 = compute_angle(&v2, &v1_start, &v1_end);
   if ((ccw_poly1 && angle1 < 0)
     || (!ccw_poly1 && angle1 > 0))
   {
     /* Found local minimum */
     double dmax = -1;
-    getPoint4d_p(poly1->rings[0], 0, &v1_start);
+    v1_start = *getPoint2d_cp(poly1->rings[0], 0);
     if (pose1)
-      apply_pose_point4d(&v1_start, pose1);
+      apply_pose_point2d(&v1_start, pose1);
     for (i1 = 0; i1 < n1; ++i1)
     {
       /* Find edge of poly1 with the largest
          positive distance to v2 */
-      getPoint4d_p(poly1->rings[0], i1 + 1, &v1_end);
+      v1_end = *getPoint2d_cp(poly1->rings[0], i1 + 1);
       if (pose1)
-        apply_pose_point4d(&v1_end, pose1);
-      angle1 = compute_angle(v2, v1_start, v1_end);
+        apply_pose_point2d(&v1_end, pose1);
+      angle1 = compute_angle(&v2, &v1_start, &v1_end);
       if ((ccw_poly1 && angle1 > 0)
         || (!ccw_poly1 && angle1 < 0))
       {
-        double distance = compute_dist2(v2, v1_start, v1_end);
+        double distance = compute_dist2(&v2, &v1_start, &v1_end);
         if (distance > dmax)
         {
           dmax = distance;
@@ -499,13 +496,13 @@ edge_vertex_tpoly_tpoly(const LWPOLY *poly1, const LWPOLY *poly2,
   v1.x = v1_start.x * (1 - s1) + v1_end.x * s1;
   v1.y = v1_start.y * (1 - s1) + v1_end.y * s1;
   /* Check if v1 is in v2's Voronoi region */
-  s2_prev = compute_s(v1, v2_prev, v2);
+  s2_prev = compute_s(&v1, &v2_prev, &v2);
   if (s2_prev + MEOS_EPSILON < 1)
   {
     *poly2_feature = uint_mod_sub(*poly2_feature, 1, 2*n2);
     return MEOS_CONTINUE;
   }
-  s2_next = compute_s(v1, v2, v2_next);
+  s2_next = compute_s(&v1, &v2, &v2_next);
   if (s2_next - MEOS_EPSILON > 0)
   {
     *poly2_feature = uint_mod_add(*poly2_feature, 1, 2*n2);
@@ -526,41 +523,41 @@ edge_edge_tpoly_tpoly(const LWPOLY *poly1, const LWPOLY *poly2,
   uint32_t *poly2_feature)
 {
   double d1_start, d1_end, d2_start, d2_end;
-  POINT4D v1_start, v1_end, v2_start, v2_end;
+  POINT2D v1_start, v1_end, v2_start, v2_end;
   uint32_t n1 = poly1->rings[0]->npoints - 1;
   uint32_t n2 = poly2->rings[0]->npoints - 1;
   uint32_t i1 = *poly1_feature / 2;
   uint32_t i2 = *poly2_feature / 2;
 
   /* Get edge endpoints of edge of poly1 */
-  getPoint4d_p(poly1->rings[0], i1, &v1_start);
-  getPoint4d_p(poly1->rings[0], uint_mod_add(i1, 1, n1), &v1_end);
+  v1_start = *getPoint2d_cp(poly1->rings[0], i1);
+  v1_end = *getPoint2d_cp(poly1->rings[0], uint_mod_add(i1, 1, n1));
   if (pose1)
   {
-    apply_pose_point4d(&v1_start, pose1);
-    apply_pose_point4d(&v1_end, pose1);
+    apply_pose_point2d(&v1_start, pose1);
+    apply_pose_point2d(&v1_end, pose1);
   }
   /* Get edge endpoints of edge of poly2 */
-  getPoint4d_p(poly2->rings[0], i2, &v2_start);
-  getPoint4d_p(poly2->rings[0], uint_mod_add(i2, 1, n2), &v2_end);
+  v2_start = *getPoint2d_cp(poly2->rings[0], i2);
+  v2_end = *getPoint2d_cp(poly2->rings[0], uint_mod_add(i2, 1, n2));
   if (pose2)
   {
-    apply_pose_point4d(&v2_start, pose2);
-    apply_pose_point4d(&v2_end, pose2);
+    apply_pose_point2d(&v2_start, pose2);
+    apply_pose_point2d(&v2_end, pose2);
   }
 
   /* Check if the edges intersect */
-  if (compute_angle(v1_start, v2_start, v2_end) *
-        compute_angle(v1_end, v2_start, v2_end) < 0 &&
-      compute_angle(v2_start, v1_start, v1_end) *
-        compute_angle(v2_end, v1_start, v1_end) < 0)
+  if (compute_angle(&v1_start, &v2_start, &v2_end) *
+        compute_angle(&v1_end, &v2_start, &v2_end) < 0 &&
+      compute_angle(&v2_start, &v1_start, &v1_end) *
+        compute_angle(&v2_end, &v1_start, &v1_end) < 0)
     return MEOS_INTERSECT;
 
   /* Compute distances of each vertex to opposing edge */
-  d1_start = compute_dist2_safe(v1_start, v2_start, v2_end);
-  d1_end = compute_dist2_safe(v1_end, v2_start, v2_end);
-  d2_start = compute_dist2_safe(v2_start, v1_start, v1_end);
-  d2_end = compute_dist2_safe(v2_end, v1_start, v1_end);
+  d1_start = compute_dist2_safe(&v1_start, &v2_start, &v2_end);
+  d1_end = compute_dist2_safe(&v1_end, &v2_start, &v2_end);
+  d2_start = compute_dist2_safe(&v2_start, &v1_start, &v1_end);
+  d2_end = compute_dist2_safe(&v2_end, &v1_start, &v1_end);
 
   /* Update vertex with the smallest distance */
   if (d1_start <= d1_end && d1_start <= d2_start && d1_start <= d2_end)
@@ -624,51 +621,51 @@ v_clip_tpoly_tpoly(const LWPOLY *poly1, const LWPOLY *poly2,
     /* compute the distance */
     if (*poly1_feature % 2 == 0 && *poly2_feature % 2 == 0) /* vertex <-> vertex */
     {
-      POINT4D v1, v2;
+      POINT2D v1, v2;
       uint32_t i1 = *poly1_feature / 2;
       uint32_t i2 = *poly2_feature / 2;
-      getPoint4d_p(poly1->rings[0], i1, &v1);
+      v1 = *getPoint2d_cp(poly1->rings[0], i1);
       if (pose1)
-        apply_pose_point4d(&v1, pose1);
-      getPoint4d_p(poly2->rings[0], i2, &v2);
+        apply_pose_point2d(&v1, pose1);
+      v2 = *getPoint2d_cp(poly2->rings[0], i2);
       if (pose2)
-        apply_pose_point4d(&v2, pose2);
+        apply_pose_point2d(&v2, pose2);
       *dist = sqrt((v1.x - v2.x) * (v1.x - v2.x) +
         (v1.y - v2.y) * (v1.y - v2.y));
     }
     else if (*poly1_feature % 2 == 0) /* vertex <-> edge */
     {
-      POINT4D v1, v2_start, v2_end;
+      POINT2D v1, v2_start, v2_end;
       uint32_t i1 = *poly1_feature / 2;
       uint32_t i2 = *poly2_feature / 2;
-      getPoint4d_p(poly1->rings[0], i1, &v1);
+      v1 = *getPoint2d_cp(poly1->rings[0], i1);
       if (pose1)
-        apply_pose_point4d(&v1, pose1);
-      getPoint4d_p(poly2->rings[0], i2, &v2_start);
-      getPoint4d_p(poly2->rings[0], i2 + 1, &v2_end);
+        apply_pose_point2d(&v1, pose1);
+      v2_start = *getPoint2d_cp(poly2->rings[0], i2);
+      v2_end = *getPoint2d_cp(poly2->rings[0], i2 + 1);
       if (pose2)
       {
-        apply_pose_point4d(&v2_start, pose2);
-        apply_pose_point4d(&v2_end, pose2);
+        apply_pose_point2d(&v2_start, pose2);
+        apply_pose_point2d(&v2_end, pose2);
       }
-      *dist = sqrt(compute_dist2(v1, v2_start, v2_end));
+      *dist = sqrt(compute_dist2(&v1, &v2_start, &v2_end));
     }
     else if (*poly2_feature % 2 == 0) /* edge <-> vertex */
     {
-      POINT4D v1_start, v1_end, v2;
+      POINT2D v1_start, v1_end, v2;
       uint32_t i1 = *poly1_feature / 2;
       uint32_t i2 = *poly2_feature / 2;
-      getPoint4d_p(poly1->rings[0], i1, &v1_start);
-      getPoint4d_p(poly1->rings[0], i1 + 1, &v1_end);
+      v1_start = *getPoint2d_cp(poly1->rings[0], i1);
+      v1_end = *getPoint2d_cp(poly1->rings[0], i1 + 1);
       if (pose1)
       {
-        apply_pose_point4d(&v1_start, pose1);
-        apply_pose_point4d(&v1_end, pose1);
+        apply_pose_point2d(&v1_start, pose1);
+        apply_pose_point2d(&v1_end, pose1);
       }
-      getPoint4d_p(poly2->rings[0], i2, &v2);
+      v2 = *getPoint2d_cp(poly2->rings[0], i2);
       if (pose2)
-        apply_pose_point4d(&v2, pose2);
-      *dist = sqrt(compute_dist2(v2, v1_start, v1_end));
+        apply_pose_point2d(&v2, pose2);
+      *dist = sqrt(compute_dist2(&v2, &v1_start, &v1_end));
     }
     else
       meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE, "V-clip: Invalid combination of current features: (%d, %d)", *poly1_feature, *poly2_feature);

--- a/meos/src/temporal/temporal_modif.c
+++ b/meos/src/temporal/temporal_modif.c
@@ -174,8 +174,8 @@ lwmline_sew(const LWMLINE *mline)
       empty[i] = used[i] = true;
       continue;
     }
-    getPoint2d_p(ln->points, 0, &head[i]);
-    getPoint2d_p(ln->points, ln->points->npoints - 1, &tail[i]);
+    head[i] = *getPoint2d_cp(ln->points, 0);
+    tail[i] = *getPoint2d_cp(ln->points, ln->points->npoints - 1);
   }
 
   /* How many line ends meet at each end, which is what tells a point the


### PR DESCRIPTION
getPoint4d_p and getPoint2d_p copy a point out of its point array: they check
the index, switch on the dimensions the array carries, copy the ordinates it
holds and fill Z and M with defaults where it holds none. getPoint2d_cp
returns a pointer into the array instead, and its X and Y are the point's
whatever dimensions the array carries. Each site below reads only X and Y
from the point it copied, so it reads the point where it lies:

- the buffer: the curve end a piece snaps to, the area of a ring, the ring
  and line vertices copied into the offset input, the removal of repeated
  line vertices, and the centre of the disc a point buffers to;
- the relationship engine: the ring and arc edges it extracts, emit_arc_edge
  taking the three points of an arc as POINT2D, and the points of a
  multipoint with their duplicate test;
- the trajectory clip: the weld test and the segment ends it classifies;
- the H3 covers: the segment ends a line covers, the loop a polygon ring
  becomes, and the point a cover starts from, once an empty point is set
  aside;
- the distance from a temporal point to a geometry: the segment its nearest
  point is located on;
- the circular buffer: the ends of a diameter;
- the merge of temporal values: the heads and tails of the lines it joins;
- the rigid geometry distance, whose walk and transition solvers read only
  X and Y: compute_s, compute_angle, compute_dist2, compute_dist2_safe and
  the three root functions take POINT2D pointers, a vertex is copied only
  where a pose places it, into the POINT2D apply_pose_point2d rotates, and
  the iterative root finds evaluate the unposed vertices in place rather than
  three POINT4D passed by value per step. The point of a temporal point
  instant is read through GSERIALIZED_POINT2D_P, and the closest instant of
  a distance through temporal_min_inst_p, the distance being freed after it.

A site that reads Z or M, or hands the point to a function taking a POINT4D,
keeps its copy.

The witness is the answer itself, bit for bit: every buffer built on the
natural-area polygons, the joint sweep, the curved shapes, the arcs at scale
2^-8, the polygons of 100 to 400 KB and the unit shapes at radii 10^3 and
10^6 is the hex EWKB master builds, 1029 answers with the same declines.

Measured: callgrind counts the temporal distances of a moving convex
pentagon, rod and square to a point, a polygon, one another and a moving
point at 356.2 million instructions on master and 285.7 million with this
change for tdistance_trgeometry_geo, 247.6 and 193.6 million for
tdistance_trgeometry_trgeometry, and 81.7 and 69.2 million for
tdistance_trgeometry_tpoint, every answer the same bit for bit. With GEOS as
a cost reference and never a witness, the relationship engine on five large
natural-area pairs stays at 33,515.5 and 33,504.6 million native
instructions against 404.3 million for GEOS as MEOS calls it. The buffer
of the 176 natural-area polygons at radius 50 goes from 27,354.3 to 27,276.0
million native instructions against 718.7 million for GEOS as MEOS calls it,
GEOS again a cost reference and never a witness.

Why: reading a point where it lies costs a pointer, while the copy costs a
call, a bounds test, a switch on the dimensions and a copy of up to four
ordinates, on paths that read every vertex of a geometry.

