### PR TITLE
Keep two geodetic edges apart where they meet only at an antipode

### DIFF
--- a/mobilitydb/test/geo/expected/064_tgeo_distance.test.out
+++ b/mobilitydb/test/geo/expected/064_tgeo_distance.test.out
@@ -875,25 +875,25 @@ SELECT asText(NearestApproachInstant(tgeometry '[Point(1 1)@2001-01-01, Point(1 
  POINT(1 1)@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(round(NearestApproachInstant(tgeography 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 90)'),6));
+SELECT asText(round(NearestApproachInstant(tgeography 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 60)'),6));
                   astext                   
 -------------------------------------------
  POINT(-90 0)@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(round(NearestApproachInstant(tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 90)'),6));
-                  astext                   
--------------------------------------------
- POINT(-90 0)@Mon Jan 01 00:00:00 2001 PST
+SELECT asText(round(NearestApproachInstant(tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 60)'),6));
+                 astext                  
+-----------------------------------------
+ POINT(0 0)@Tue Jan 02 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(round(NearestApproachInstant(tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 90)'),6));
-                  astext                   
--------------------------------------------
- POINT(-90 0)@Mon Jan 01 00:00:00 2001 PST
+SELECT asText(round(NearestApproachInstant(tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 60)'),6));
+                 astext                  
+-----------------------------------------
+ POINT(0 0)@Tue Jan 02 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(round(NearestApproachInstant(tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 90)'),6));
+SELECT asText(round(NearestApproachInstant(tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 60)'),6));
                   astext                   
 -------------------------------------------
  POINT(90 90)@Thu Jan 04 00:00:00 2001 PST
@@ -971,25 +971,25 @@ SELECT asText(NearestApproachInstant(geometry 'Linestring empty', tgeometry '{[P
  
 (1 row)
 
-SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 90)', tgeography 'Point(-90 0)@2001-01-01'));
+SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 60)', tgeography 'Point(-90 0)@2001-01-01'));
                   astext                   
 -------------------------------------------
  POINT(-90 0)@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 90)', tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'));
-                  astext                   
--------------------------------------------
- POINT(-90 0)@Mon Jan 01 00:00:00 2001 PST
+SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 60)', tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'));
+                 astext                  
+-----------------------------------------
+ POINT(0 0)@Tue Jan 02 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 90)', tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'));
-                  astext                   
--------------------------------------------
- POINT(-90 0)@Mon Jan 01 00:00:00 2001 PST
+SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 60)', tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'));
+                 astext                  
+-----------------------------------------
+ POINT(0 0)@Tue Jan 02 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 90)', tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'));
+SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 60)', tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'));
                   astext                   
 -------------------------------------------
  POINT(90 90)@Thu Jan 04 00:00:00 2001 PST
@@ -1524,28 +1524,28 @@ SELECT round(NearestApproachDistance(tgeometry '{[Point(1 1 1)@2001-01-01, Point
       
 (1 row)
 
-SELECT round(NearestApproachDistance(tgeography 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 90)'), 6);
-      round      
------------------
- 10001965.729313
+SELECT round(NearestApproachDistance(tgeography 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 60)'), 0);
+  round   
+----------
+ 10006183
 (1 row)
 
-SELECT round(NearestApproachDistance(tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 90)'), 6);
-      round      
------------------
- 10001965.729313
+SELECT round(NearestApproachDistance(tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 60)'), 0);
+  round  
+---------
+ 6654073
 (1 row)
 
-SELECT round(NearestApproachDistance(tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 90)'), 6);
-      round      
------------------
- 10001965.729313
+SELECT round(NearestApproachDistance(tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 60)'), 0);
+  round  
+---------
+ 6654073
 (1 row)
 
-SELECT round(NearestApproachDistance(tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 90)'), 6);
- round 
--------
-     0
+SELECT round(NearestApproachDistance(tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 60)'), 0);
+  round  
+---------
+ 3347893
 (1 row)
 
 SELECT round(NearestApproachDistance(tgeography 'Point(-90 0)@2001-01-01', geography 'Linestring empty'), 6);
@@ -1716,28 +1716,28 @@ SELECT round(NearestApproachDistance(geometry 'Linestring Z empty', tgeometry '{
       
 (1 row)
 
-SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 90)', tgeography 'Point(-90 0)@2001-01-01'), 6);
-      round      
------------------
- 10001965.729313
+SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 60)', tgeography 'Point(-90 0)@2001-01-01'), 0);
+  round   
+----------
+ 10006183
 (1 row)
 
-SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 90)', tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 6);
-      round      
------------------
- 10001965.729313
+SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 60)', tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 0);
+  round  
+---------
+ 6654073
 (1 row)
 
-SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 90)', tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'), 6);
-      round      
------------------
- 10001965.729313
+SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 60)', tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'), 0);
+  round  
+---------
+ 6654073
 (1 row)
 
-SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 90)', tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'), 6);
- round 
--------
-     0
+SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 60)', tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'), 0);
+  round  
+---------
+ 3347893
 (1 row)
 
 SELECT round(NearestApproachDistance(geography 'Linestring empty', tgeography 'Point(-90 0)@2001-01-01'), 6);
@@ -2402,28 +2402,28 @@ SELECT round((tgeometry '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Poi
       
 (1 row)
 
-SELECT round((tgeography 'Point(-90 0)@2001-01-01' |=| geography 'Linestring(90 0,0 90)'), 6);
-      round      
------------------
- 10001965.729313
+SELECT round((tgeography 'Point(-90 0)@2001-01-01' |=| geography 'Linestring(90 0,0 60)'), 0);
+  round   
+----------
+ 10006183
 (1 row)
 
-SELECT round((tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}' |=| geography 'Linestring(90 0,0 90)'), 6);
-      round      
------------------
- 10001965.729313
+SELECT round((tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}' |=| geography 'Linestring(90 0,0 60)'), 0);
+  round  
+---------
+ 6654073
 (1 row)
 
-SELECT round((tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]' |=| geography 'Linestring(90 0,0 90)'), 6);
-      round      
------------------
- 10001965.729313
+SELECT round((tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]' |=| geography 'Linestring(90 0,0 60)'), 0);
+  round  
+---------
+ 6654073
 (1 row)
 
-SELECT round((tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}' |=| geography 'Linestring(90 0,0 90)'), 6);
- round 
--------
-     0
+SELECT round((tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}' |=| geography 'Linestring(90 0,0 60)'), 0);
+  round  
+---------
+ 3347893
 (1 row)
 
 SELECT round((tgeography 'Point(-90 0)@2001-01-01' |=| geography 'Linestring empty'), 6);
@@ -2594,28 +2594,28 @@ SELECT round((geometry 'Linestring Z empty' |=| tgeometry '{[Point(1 1 1)@2001-0
       
 (1 row)
 
-SELECT round((geography 'Linestring(90 0,0 90)' |=| tgeography 'Point(-90 0)@2001-01-01'), 6);
-      round      
------------------
- 10001965.729313
+SELECT round((geography 'Linestring(90 0,0 60)' |=| tgeography 'Point(-90 0)@2001-01-01'), 0);
+  round   
+----------
+ 10006183
 (1 row)
 
-SELECT round((geography 'Linestring(90 0,0 90)' |=| tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 6);
-      round      
------------------
- 10001965.729313
+SELECT round((geography 'Linestring(90 0,0 60)' |=| tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 0);
+  round  
+---------
+ 6654073
 (1 row)
 
-SELECT round((geography 'Linestring(90 0,0 90)' |=| tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'), 6);
-      round      
------------------
- 10001965.729313
+SELECT round((geography 'Linestring(90 0,0 60)' |=| tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'), 0);
+  round  
+---------
+ 6654073
 (1 row)
 
-SELECT round((geography 'Linestring(90 0,0 90)' |=| tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'), 6);
- round 
--------
-     0
+SELECT round((geography 'Linestring(90 0,0 60)' |=| tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'), 0);
+  round  
+---------
+ 3347893
 (1 row)
 
 SELECT round((geography 'Linestring empty' |=| tgeography 'Point(-90 0)@2001-01-01'), 6);
@@ -3183,28 +3183,28 @@ SELECT ST_AsTexT(shortestLine(tgeometry '{[Point(1 1 1)@2001-01-01, Point(2 2 2)
  
 (1 row)
 
-SELECT ST_AsTexT(shortestLine(tgeography 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 90)'), 1);
+SELECT ST_AsTexT(shortestLine(tgeography 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 60)'), 1);
        st_astext        
 ------------------------
- LINESTRING(-90 0,0 90)
+ LINESTRING(-90 0,0 60)
 (1 row)
 
-SELECT ST_AsTexT(shortestLine(tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 90)'), 1);
+SELECT ST_AsTexT(round(shortestLine(tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 60)')), 6);
       st_astext       
 ----------------------
- LINESTRING(0 0,90 0)
+ LINESTRING(0 0,0 60)
 (1 row)
 
-SELECT ST_AsTexT(shortestLine(tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 90)'), 1);
+SELECT ST_AsTexT(round(shortestLine(tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 60)')), 6);
       st_astext       
 ----------------------
- LINESTRING(0 0,90 0)
+ LINESTRING(0 0,0 60)
 (1 row)
 
-SELECT ST_AsTexT(shortestLine(tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 90)'), 1);
-        st_astext        
--------------------------
- LINESTRING(90 90,45 90)
+SELECT ST_AsTexT(round(shortestLine(tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 60)')), 6);
+       st_astext        
+------------------------
+ LINESTRING(90 90,0 60)
 (1 row)
 
 SELECT ST_AsTexT(shortestLine(tgeography 'Point(-90 0)@2001-01-01', geography 'Linestring empty'));
@@ -3327,28 +3327,28 @@ SELECT ST_AsTexT(shortestLine(geometry 'Linestring Z empty', tgeometry '{[Point(
  
 (1 row)
 
-SELECT ST_AsTexT(shortestLine(geography 'Linestring(90 0,0 90)', tgeography 'Point(-90 0)@2001-01-01'), 1);
+SELECT ST_AsTexT(shortestLine(geography 'Linestring(90 0,0 60)', tgeography 'Point(-90 0)@2001-01-01'), 1);
        st_astext        
 ------------------------
- LINESTRING(-90 0,0 90)
+ LINESTRING(-90 0,0 60)
 (1 row)
 
-SELECT ST_AsTexT(shortestLine(geography 'Linestring(90 0,0 90)', tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 1);
+SELECT ST_AsTexT(round(shortestLine(geography 'Linestring(90 0,0 60)', tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}')), 6);
       st_astext       
 ----------------------
- LINESTRING(0 0,90 0)
+ LINESTRING(0 0,0 60)
 (1 row)
 
-SELECT ST_AsTexT(shortestLine(geography 'Linestring(90 0,0 90)', tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'), 1);
+SELECT ST_AsTexT(round(shortestLine(geography 'Linestring(90 0,0 60)', tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]')), 6);
       st_astext       
 ----------------------
- LINESTRING(0 0,90 0)
+ LINESTRING(0 0,0 60)
 (1 row)
 
-SELECT ST_AsTexT(shortestLine(geography 'Linestring(90 0,0 90)', tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'), 1);
-        st_astext        
--------------------------
- LINESTRING(90 90,45 90)
+SELECT ST_AsTexT(round(shortestLine(geography 'Linestring(90 0,0 60)', tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}')), 6);
+       st_astext        
+------------------------
+ LINESTRING(90 90,0 60)
 (1 row)
 
 SELECT ST_AsTexT(shortestLine(geography 'Linestring empty', tgeography 'Point(-90 0)@2001-01-01'), 1);

--- a/mobilitydb/test/geo/expected/064_tpoint_distance.test.out
+++ b/mobilitydb/test/geo/expected/064_tpoint_distance.test.out
@@ -907,37 +907,37 @@ SELECT asText(NearestApproachInstant(tgeompoint '[Point(1 1)@2001-01-01, Point(1
  POINT(1 1)@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(round(NearestApproachInstant(tgeogpoint 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 90)'),6));
+SELECT asText(round(NearestApproachInstant(tgeogpoint 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 60)'),6));
                   astext                   
 -------------------------------------------
  POINT(-90 0)@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(round(NearestApproachInstant(tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 90)'),6));
-                  astext                   
--------------------------------------------
- POINT(-90 0)@Mon Jan 01 00:00:00 2001 PST
+SELECT asText(round(NearestApproachInstant(tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 60)'),6));
+                 astext                  
+-----------------------------------------
+ POINT(0 0)@Tue Jan 02 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(round(NearestApproachInstant(tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 90)'),6));
-                  astext                   
--------------------------------------------
- POINT(-90 0)@Mon Jan 01 00:00:00 2001 PST
+SELECT asText(round(NearestApproachInstant(tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 60)'),6));
+                 astext                  
+-----------------------------------------
+ POINT(0 0)@Tue Jan 02 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(round(NearestApproachInstant(tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 90)'),6));
+SELECT asText(round(NearestApproachInstant(tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 60)'),6));
                   astext                   
 -------------------------------------------
- POINT(-90 0)@Mon Jan 01 00:00:00 2001 PST
+ POINT(90 90)@Thu Jan 04 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(NearestApproachInstant(tgeogpoint 'Interp=Step;[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 90)'));
-                  astext                   
--------------------------------------------
- POINT(-90 0)@Mon Jan 01 00:00:00 2001 PST
+SELECT asText(NearestApproachInstant(tgeogpoint 'Interp=Step;[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 60)'));
+                 astext                  
+-----------------------------------------
+ POINT(0 0)@Tue Jan 02 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(NearestApproachInstant(tgeogpoint 'Interp=Step;{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 90)'));
+SELECT asText(NearestApproachInstant(tgeogpoint 'Interp=Step;{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 60)'));
                   astext                   
 -------------------------------------------
  POINT(90 90)@Thu Jan 04 00:00:00 2001 PST
@@ -1027,28 +1027,28 @@ SELECT asText(NearestApproachInstant(geometry 'Linestring empty', tgeompoint '{[
  
 (1 row)
 
-SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 90)', tgeogpoint 'Point(-90 0)@2001-01-01'));
+SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 60)', tgeogpoint 'Point(-90 0)@2001-01-01'));
                   astext                   
 -------------------------------------------
  POINT(-90 0)@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 90)', tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'));
-                  astext                   
--------------------------------------------
- POINT(-90 0)@Mon Jan 01 00:00:00 2001 PST
+SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 60)', tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'));
+                 astext                  
+-----------------------------------------
+ POINT(0 0)@Tue Jan 02 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 90)', tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'));
-                  astext                   
--------------------------------------------
- POINT(-90 0)@Mon Jan 01 00:00:00 2001 PST
+SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 60)', tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'));
+                 astext                  
+-----------------------------------------
+ POINT(0 0)@Tue Jan 02 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 90)', tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'));
+SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 60)', tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'));
                   astext                   
 -------------------------------------------
- POINT(-90 0)@Mon Jan 01 00:00:00 2001 PST
+ POINT(90 90)@Thu Jan 04 00:00:00 2001 PST
 (1 row)
 
 SELECT asText(NearestApproachInstant(geography 'Linestring empty', tgeogpoint 'Point(-90 0)@2001-01-01'));
@@ -1628,28 +1628,28 @@ SELECT round(NearestApproachDistance(tgeompoint 'Interp=Step;{[Point(1 1 1)@2001
       
 (1 row)
 
-SELECT round(NearestApproachDistance(tgeogpoint 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 90)'), 6);
-      round      
------------------
- 10001965.729313
+SELECT round(NearestApproachDistance(tgeogpoint 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 60)'), 0);
+  round   
+----------
+ 10006183
 (1 row)
 
-SELECT round(NearestApproachDistance(tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 90)'), 6);
-      round      
------------------
- 10001965.729313
+SELECT round(NearestApproachDistance(tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 60)'), 0);
+  round  
+---------
+ 6654073
 (1 row)
 
-SELECT round(NearestApproachDistance(tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 90)'), 6);
- round 
--------
-     0
+SELECT round(NearestApproachDistance(tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 60)'), 0);
+  round  
+---------
+ 6654073
 (1 row)
 
-SELECT round(NearestApproachDistance(tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 90)'), 6);
- round 
--------
-     0
+SELECT round(NearestApproachDistance(tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 60)'), 0);
+  round  
+---------
+ 3347893
 (1 row)
 
 SELECT round(NearestApproachDistance(tgeogpoint 'Point(-90 0)@2001-01-01', geography 'Linestring empty'), 6);
@@ -1689,9 +1689,9 @@ SELECT round(NearestApproachDistance(tgeogpoint '{Point(-90 0 100)@2001-01-01, P
 (1 row)
 
 SELECT round(NearestApproachDistance(tgeogpoint '[Point(-90 0 100)@2001-01-01, Point(0 0 100)@2001-01-02, Point(-90 0 100)@2001-01-03]', geography 'Linestring(90 0 0,0 90 100)'), 6);
- round 
--------
-     0
+      round      
+-----------------
+ 10018754.171395
 (1 row)
 
 SELECT round(NearestApproachDistance(tgeogpoint '{[Point(-90 0 100)@2001-01-01, Point(0 0 100)@2001-01-02, Point(-90 0 100)@2001-01-03],[Point(90 90 100)@2001-01-04, Point(90 90 100)@2001-01-05]}', geography 'Linestring(90 0 0,0 90 100)'), 6);
@@ -1820,28 +1820,28 @@ SELECT round(NearestApproachDistance(geometry 'Linestring Z empty', tgeompoint '
       
 (1 row)
 
-SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 90)', tgeogpoint 'Point(-90 0)@2001-01-01'), 6);
-      round      
------------------
- 10001965.729313
+SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 60)', tgeogpoint 'Point(-90 0)@2001-01-01'), 0);
+  round   
+----------
+ 10006183
 (1 row)
 
-SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 90)', tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 6);
-      round      
------------------
- 10001965.729313
+SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 60)', tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 0);
+  round  
+---------
+ 6654073
 (1 row)
 
-SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 90)', tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'), 6);
- round 
--------
-     0
+SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 60)', tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'), 0);
+  round  
+---------
+ 6654073
 (1 row)
 
-SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 90)', tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'), 6);
- round 
--------
-     0
+SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 60)', tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'), 0);
+  round  
+---------
+ 3347893
 (1 row)
 
 SELECT round(NearestApproachDistance(geography 'Linestring empty', tgeogpoint 'Point(-90 0)@2001-01-01'), 6);
@@ -1881,9 +1881,9 @@ SELECT round(NearestApproachDistance(geography 'Linestring(90 0 0,0 90 100)', tg
 (1 row)
 
 SELECT round(NearestApproachDistance(geography 'Linestring(90 0 0,0 90 100)', tgeogpoint '[Point(-90 0 100)@2001-01-01, Point(0 0 100)@2001-01-02, Point(-90 0 100)@2001-01-03]'), 6);
- round 
--------
-     0
+      round      
+-----------------
+ 10018754.171395
 (1 row)
 
 SELECT round(NearestApproachDistance(geography 'Linestring(90 0 0,0 90 100)', tgeogpoint '{[Point(-90 0 100)@2001-01-01, Point(0 0 100)@2001-01-02, Point(-90 0 100)@2001-01-03],[Point(90 90 100)@2001-01-04, Point(90 90 100)@2001-01-05]}'), 6);
@@ -2518,28 +2518,28 @@ SELECT round((tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Po
       
 (1 row)
 
-SELECT round((tgeogpoint 'Point(-90 0)@2001-01-01' |=| geography 'Linestring(90 0,0 90)'), 6);
-      round      
------------------
- 10001965.729313
+SELECT round((tgeogpoint 'Point(-90 0)@2001-01-01' |=| geography 'Linestring(90 0,0 60)'), 0);
+  round   
+----------
+ 10006183
 (1 row)
 
-SELECT round((tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}' |=| geography 'Linestring(90 0,0 90)'), 6);
-      round      
------------------
- 10001965.729313
+SELECT round((tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}' |=| geography 'Linestring(90 0,0 60)'), 0);
+  round  
+---------
+ 6654073
 (1 row)
 
-SELECT round((tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]' |=| geography 'Linestring(90 0,0 90)'), 6);
- round 
--------
-     0
+SELECT round((tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]' |=| geography 'Linestring(90 0,0 60)'), 0);
+  round  
+---------
+ 6654073
 (1 row)
 
-SELECT round((tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}' |=| geography 'Linestring(90 0,0 90)'), 6);
- round 
--------
-     0
+SELECT round((tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}' |=| geography 'Linestring(90 0,0 60)'), 0);
+  round  
+---------
+ 3347893
 (1 row)
 
 SELECT round((tgeogpoint 'Point(-90 0)@2001-01-01' |=| geography 'Linestring empty'), 6);
@@ -2579,9 +2579,9 @@ SELECT round((tgeogpoint '{Point(-90 0 100)@2001-01-01, Point(0 0 100)@2001-01-0
 (1 row)
 
 SELECT round((tgeogpoint '[Point(-90 0 100)@2001-01-01, Point(0 0 100)@2001-01-02, Point(-90 0 100)@2001-01-03]' |=| geography 'Linestring(90 0 0,0 90 100)'), 6);
- round 
--------
-     0
+      round      
+-----------------
+ 10018754.171395
 (1 row)
 
 SELECT round((tgeogpoint '{[Point(-90 0 100)@2001-01-01, Point(0 0 100)@2001-01-02, Point(-90 0 100)@2001-01-03],[Point(90 90 100)@2001-01-04, Point(90 90 100)@2001-01-05]}' |=| geography 'Linestring(90 0 0,0 90 100)'), 6);
@@ -2710,28 +2710,28 @@ SELECT round((geometry 'Linestring Z empty' |=| tgeompoint '{[Point(1 1 1)@2001-
       
 (1 row)
 
-SELECT round((geography 'Linestring(90 0,0 90)' |=| tgeogpoint 'Point(-90 0)@2001-01-01'), 6);
-      round      
------------------
- 10001965.729313
+SELECT round((geography 'Linestring(90 0,0 60)' |=| tgeogpoint 'Point(-90 0)@2001-01-01'), 0);
+  round   
+----------
+ 10006183
 (1 row)
 
-SELECT round((geography 'Linestring(90 0,0 90)' |=| tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 6);
-      round      
------------------
- 10001965.729313
+SELECT round((geography 'Linestring(90 0,0 60)' |=| tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 0);
+  round  
+---------
+ 6654073
 (1 row)
 
-SELECT round((geography 'Linestring(90 0,0 90)' |=| tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'), 6);
- round 
--------
-     0
+SELECT round((geography 'Linestring(90 0,0 60)' |=| tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'), 0);
+  round  
+---------
+ 6654073
 (1 row)
 
-SELECT round((geography 'Linestring(90 0,0 90)' |=| tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'), 6);
- round 
--------
-     0
+SELECT round((geography 'Linestring(90 0,0 60)' |=| tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'), 0);
+  round  
+---------
+ 3347893
 (1 row)
 
 SELECT round((geography 'Linestring empty' |=| tgeogpoint 'Point(-90 0)@2001-01-01'), 6);
@@ -2771,9 +2771,9 @@ SELECT round((geography 'Linestring(90 0 0,0 90 100)' |=| tgeogpoint '{Point(-90
 (1 row)
 
 SELECT round((geography 'Linestring(90 0 0,0 90 100)' |=| tgeogpoint '[Point(-90 0 100)@2001-01-01, Point(0 0 100)@2001-01-02, Point(-90 0 100)@2001-01-03]'), 6);
- round 
--------
-     0
+      round      
+-----------------
+ 10018754.171395
 (1 row)
 
 SELECT round((geography 'Linestring(90 0 0,0 90 100)' |=| tgeogpoint '{[Point(-90 0 100)@2001-01-01, Point(0 0 100)@2001-01-02, Point(-90 0 100)@2001-01-03],[Point(90 90 100)@2001-01-04, Point(90 90 100)@2001-01-05]}'), 6);
@@ -3299,28 +3299,28 @@ SELECT ST_AsTexT(shortestLine(tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2
  
 (1 row)
 
-SELECT ST_AsTexT(shortestLine(tgeogpoint 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 90)'), 1);
+SELECT ST_AsTexT(shortestLine(tgeogpoint 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 60)'), 1);
        st_astext        
 ------------------------
- LINESTRING(-90 0,0 90)
+ LINESTRING(-90 0,0 60)
 (1 row)
 
-SELECT ST_AsTexT(shortestLine(tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 90)'), 1);
+SELECT ST_AsTexT(round(shortestLine(tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 60)')), 6);
       st_astext       
 ----------------------
- LINESTRING(0 0,90 0)
+ LINESTRING(0 0,0 60)
 (1 row)
 
-SELECT ST_AsTexT(shortestLine(tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 90)'), 1);
-        st_astext        
--------------------------
- LINESTRING(-90 0,-90 0)
+SELECT ST_AsTexT(round(shortestLine(tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 60)')), 6);
+      st_astext       
+----------------------
+ LINESTRING(0 0,0 60)
 (1 row)
 
-SELECT ST_AsTexT(shortestLine(tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 90)'), 1);
-        st_astext        
--------------------------
- LINESTRING(-90 0,-90 0)
+SELECT ST_AsTexT(round(shortestLine(tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 60)')), 6);
+       st_astext        
+------------------------
+ LINESTRING(90 90,0 60)
 (1 row)
 
 SELECT ST_AsTexT(shortestLine(tgeogpoint 'Point(-90 0)@2001-01-01', geography 'Linestring empty'));
@@ -3443,28 +3443,28 @@ SELECT ST_AsTexT(shortestLine(geometry 'Linestring Z empty', tgeompoint '{[Point
  
 (1 row)
 
-SELECT ST_AsTexT(shortestLine(geography 'Linestring(90 0,0 90)', tgeogpoint 'Point(-90 0)@2001-01-01'), 1);
+SELECT ST_AsTexT(shortestLine(geography 'Linestring(90 0,0 60)', tgeogpoint 'Point(-90 0)@2001-01-01'), 1);
        st_astext        
 ------------------------
- LINESTRING(-90 0,0 90)
+ LINESTRING(-90 0,0 60)
 (1 row)
 
-SELECT ST_AsTexT(shortestLine(geography 'Linestring(90 0,0 90)', tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 1);
+SELECT ST_AsTexT(round(shortestLine(geography 'Linestring(90 0,0 60)', tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}')), 6);
       st_astext       
 ----------------------
- LINESTRING(0 0,90 0)
+ LINESTRING(0 0,0 60)
 (1 row)
 
-SELECT ST_AsTexT(shortestLine(geography 'Linestring(90 0,0 90)', tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'), 1);
-        st_astext        
--------------------------
- LINESTRING(-90 0,-90 0)
+SELECT ST_AsTexT(round(shortestLine(geography 'Linestring(90 0,0 60)', tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]')), 6);
+      st_astext       
+----------------------
+ LINESTRING(0 0,0 60)
 (1 row)
 
-SELECT ST_AsTexT(shortestLine(geography 'Linestring(90 0,0 90)', tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'), 1);
-        st_astext        
--------------------------
- LINESTRING(-90 0,-90 0)
+SELECT ST_AsTexT(round(shortestLine(geography 'Linestring(90 0,0 60)', tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}')), 6);
+       st_astext        
+------------------------
+ LINESTRING(90 90,0 60)
 (1 row)
 
 SELECT ST_AsTexT(shortestLine(geography 'Linestring empty', tgeogpoint 'Point(-90 0)@2001-01-01'), 1);

--- a/mobilitydb/test/geo/queries/064_tgeo_distance.test.sql
+++ b/mobilitydb/test/geo/queries/064_tgeo_distance.test.sql
@@ -210,10 +210,10 @@ SELECT asText(NearestApproachInstant(tgeometry '{[Point(1 1)@2001-01-01, Point(2
 
 SELECT asText(NearestApproachInstant(tgeometry '[Point(1 1)@2001-01-01, Point(1 1)@2001-01-02]', geometry 'Linestring(1 1,3 3)'));
 
-SELECT asText(round(NearestApproachInstant(tgeography 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 90)'),6));
-SELECT asText(round(NearestApproachInstant(tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 90)'),6));
-SELECT asText(round(NearestApproachInstant(tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 90)'),6));
-SELECT asText(round(NearestApproachInstant(tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 90)'),6));
+SELECT asText(round(NearestApproachInstant(tgeography 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 60)'),6));
+SELECT asText(round(NearestApproachInstant(tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 60)'),6));
+SELECT asText(round(NearestApproachInstant(tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 60)'),6));
+SELECT asText(round(NearestApproachInstant(tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 60)'),6));
 SELECT asText(round(NearestApproachInstant(tgeography 'Point(-90 0)@2001-01-01', geography 'Linestring empty'),6));
 SELECT asText(round(NearestApproachInstant(tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring empty'),6));
 SELECT asText(round(NearestApproachInstant(tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring empty'),6));
@@ -229,10 +229,10 @@ SELECT asText(NearestApproachInstant(geometry 'Linestring empty', tgeometry '{Po
 SELECT asText(NearestApproachInstant(geometry 'Linestring empty', tgeometry '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]'));
 SELECT asText(NearestApproachInstant(geometry 'Linestring empty', tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}'));
 
-SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 90)', tgeography 'Point(-90 0)@2001-01-01'));
-SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 90)', tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'));
-SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 90)', tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'));
-SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 90)', tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'));
+SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 60)', tgeography 'Point(-90 0)@2001-01-01'));
+SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 60)', tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'));
+SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 60)', tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'));
+SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 60)', tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'));
 
 SELECT asText(NearestApproachInstant(geography 'Linestring empty', tgeography 'Point(-90 0)@2001-01-01'));
 SELECT asText(NearestApproachInstant(geography 'Linestring empty', tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'));
@@ -340,10 +340,10 @@ SELECT round(NearestApproachDistance(tgeometry '{Point(1 1 1)@2001-01-01, Point(
 SELECT round(NearestApproachDistance(tgeometry '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]', geometry 'Linestring Z empty'), 6);
 SELECT round(NearestApproachDistance(tgeometry '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}', geometry 'Linestring Z empty'), 6);
 
-SELECT round(NearestApproachDistance(tgeography 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 90)'), 6);
-SELECT round(NearestApproachDistance(tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 90)'), 6);
-SELECT round(NearestApproachDistance(tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 90)'), 6);
-SELECT round(NearestApproachDistance(tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 90)'), 6);
+SELECT round(NearestApproachDistance(tgeography 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 60)'), 0);
+SELECT round(NearestApproachDistance(tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 60)'), 0);
+SELECT round(NearestApproachDistance(tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 60)'), 0);
+SELECT round(NearestApproachDistance(tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 60)'), 0);
 
 SELECT round(NearestApproachDistance(tgeography 'Point(-90 0)@2001-01-01', geography 'Linestring empty'), 6);
 SELECT round(NearestApproachDistance(tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring empty'), 6);
@@ -380,10 +380,10 @@ SELECT round(NearestApproachDistance(geometry 'Linestring Z empty', tgeometry '{
 SELECT round(NearestApproachDistance(geometry 'Linestring Z empty', tgeometry '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]'), 6);
 SELECT round(NearestApproachDistance(geometry 'Linestring Z empty', tgeometry '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}'), 6);
 
-SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 90)', tgeography 'Point(-90 0)@2001-01-01'), 6);
-SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 90)', tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 6);
-SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 90)', tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'), 6);
-SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 90)', tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'), 6);
+SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 60)', tgeography 'Point(-90 0)@2001-01-01'), 0);
+SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 60)', tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 0);
+SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 60)', tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'), 0);
+SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 60)', tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'), 0);
 
 SELECT round(NearestApproachDistance(geography 'Linestring empty', tgeography 'Point(-90 0)@2001-01-01'), 6);
 SELECT round(NearestApproachDistance(geography 'Linestring empty', tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 6);
@@ -521,10 +521,10 @@ SELECT round((tgeometry '{Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Poin
 SELECT round((tgeometry '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]' |=| geometry 'Linestring Z empty'), 6);
 SELECT round((tgeometry '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}' |=| geometry 'Linestring Z empty'), 6);
 
-SELECT round((tgeography 'Point(-90 0)@2001-01-01' |=| geography 'Linestring(90 0,0 90)'), 6);
-SELECT round((tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}' |=| geography 'Linestring(90 0,0 90)'), 6);
-SELECT round((tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]' |=| geography 'Linestring(90 0,0 90)'), 6);
-SELECT round((tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}' |=| geography 'Linestring(90 0,0 90)'), 6);
+SELECT round((tgeography 'Point(-90 0)@2001-01-01' |=| geography 'Linestring(90 0,0 60)'), 0);
+SELECT round((tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}' |=| geography 'Linestring(90 0,0 60)'), 0);
+SELECT round((tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]' |=| geography 'Linestring(90 0,0 60)'), 0);
+SELECT round((tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}' |=| geography 'Linestring(90 0,0 60)'), 0);
 
 SELECT round((tgeography 'Point(-90 0)@2001-01-01' |=| geography 'Linestring empty'), 6);
 SELECT round((tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}' |=| geography 'Linestring empty'), 6);
@@ -561,10 +561,10 @@ SELECT round((geometry 'Linestring Z empty' |=| tgeometry '{Point(1 1 1)@2001-01
 SELECT round((geometry 'Linestring Z empty' |=| tgeometry '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]'), 6);
 SELECT round((geometry 'Linestring Z empty' |=| tgeometry '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}'), 6);
 
-SELECT round((geography 'Linestring(90 0,0 90)' |=| tgeography 'Point(-90 0)@2001-01-01'), 6);
-SELECT round((geography 'Linestring(90 0,0 90)' |=| tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 6);
-SELECT round((geography 'Linestring(90 0,0 90)' |=| tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'), 6);
-SELECT round((geography 'Linestring(90 0,0 90)' |=| tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'), 6);
+SELECT round((geography 'Linestring(90 0,0 60)' |=| tgeography 'Point(-90 0)@2001-01-01'), 0);
+SELECT round((geography 'Linestring(90 0,0 60)' |=| tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 0);
+SELECT round((geography 'Linestring(90 0,0 60)' |=| tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'), 0);
+SELECT round((geography 'Linestring(90 0,0 60)' |=| tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'), 0);
 
 SELECT round((geography 'Linestring empty' |=| tgeography 'Point(-90 0)@2001-01-01'), 6);
 SELECT round((geography 'Linestring empty' |=| tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 6);
@@ -679,10 +679,10 @@ SELECT ST_AsTexT(shortestLine(tgeometry '{Point(1 1 1)@2001-01-01, Point(2 2 2)@
 SELECT ST_AsTexT(shortestLine(tgeometry '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]', geometry 'Linestring Z empty'));
 SELECT ST_AsTexT(shortestLine(tgeometry '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}', geometry 'Linestring Z empty'));
 
-SELECT ST_AsTexT(shortestLine(tgeography 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 90)'), 1);
-SELECT ST_AsTexT(shortestLine(tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 90)'), 1);
-SELECT ST_AsTexT(shortestLine(tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 90)'), 1);
-SELECT ST_AsTexT(shortestLine(tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 90)'), 1);
+SELECT ST_AsTexT(shortestLine(tgeography 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 60)'), 1);
+SELECT ST_AsTexT(round(shortestLine(tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 60)')), 6);
+SELECT ST_AsTexT(round(shortestLine(tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 60)')), 6);
+SELECT ST_AsTexT(round(shortestLine(tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 60)')), 6);
 
 SELECT ST_AsTexT(shortestLine(tgeography 'Point(-90 0)@2001-01-01', geography 'Linestring empty'));
 SELECT ST_AsTexT(shortestLine(tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring empty'));
@@ -709,10 +709,10 @@ SELECT ST_AsTexT(shortestLine(geometry 'Linestring Z empty', tgeometry '{Point(1
 SELECT ST_AsTexT(shortestLine(geometry 'Linestring Z empty', tgeometry '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]'));
 SELECT ST_AsTexT(shortestLine(geometry 'Linestring Z empty', tgeometry '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}'));
 
-SELECT ST_AsTexT(shortestLine(geography 'Linestring(90 0,0 90)', tgeography 'Point(-90 0)@2001-01-01'), 1);
-SELECT ST_AsTexT(shortestLine(geography 'Linestring(90 0,0 90)', tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 1);
-SELECT ST_AsTexT(shortestLine(geography 'Linestring(90 0,0 90)', tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'), 1);
-SELECT ST_AsTexT(shortestLine(geography 'Linestring(90 0,0 90)', tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'), 1);
+SELECT ST_AsTexT(shortestLine(geography 'Linestring(90 0,0 60)', tgeography 'Point(-90 0)@2001-01-01'), 1);
+SELECT ST_AsTexT(round(shortestLine(geography 'Linestring(90 0,0 60)', tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}')), 6);
+SELECT ST_AsTexT(round(shortestLine(geography 'Linestring(90 0,0 60)', tgeography '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]')), 6);
+SELECT ST_AsTexT(round(shortestLine(geography 'Linestring(90 0,0 60)', tgeography '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}')), 6);
 
 SELECT ST_AsTexT(shortestLine(geography 'Linestring empty', tgeography 'Point(-90 0)@2001-01-01'), 1);
 SELECT ST_AsTexT(shortestLine(geography 'Linestring empty', tgeography '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 1);

--- a/mobilitydb/test/geo/queries/064_tpoint_distance.test.sql
+++ b/mobilitydb/test/geo/queries/064_tpoint_distance.test.sql
@@ -215,12 +215,12 @@ SELECT asText(NearestApproachInstant(tgeompoint 'Interp=Step;{[Point(1 1)@2001-0
 
 SELECT asText(NearestApproachInstant(tgeompoint '[Point(1 1)@2001-01-01, Point(1 1)@2001-01-02]', geometry 'Linestring(1 1,3 3)'));
 
-SELECT asText(round(NearestApproachInstant(tgeogpoint 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 90)'),6));
-SELECT asText(round(NearestApproachInstant(tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 90)'),6));
-SELECT asText(round(NearestApproachInstant(tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 90)'),6));
-SELECT asText(round(NearestApproachInstant(tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 90)'),6));
-SELECT asText(NearestApproachInstant(tgeogpoint 'Interp=Step;[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 90)'));
-SELECT asText(NearestApproachInstant(tgeogpoint 'Interp=Step;{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 90)'));
+SELECT asText(round(NearestApproachInstant(tgeogpoint 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 60)'),6));
+SELECT asText(round(NearestApproachInstant(tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 60)'),6));
+SELECT asText(round(NearestApproachInstant(tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 60)'),6));
+SELECT asText(round(NearestApproachInstant(tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 60)'),6));
+SELECT asText(NearestApproachInstant(tgeogpoint 'Interp=Step;[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 60)'));
+SELECT asText(NearestApproachInstant(tgeogpoint 'Interp=Step;{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 60)'));
 SELECT asText(round(NearestApproachInstant(tgeogpoint 'Point(-90 0)@2001-01-01', geography 'Linestring empty'),6));
 SELECT asText(round(NearestApproachInstant(tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring empty'),6));
 SELECT asText(round(NearestApproachInstant(tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring empty'),6));
@@ -238,10 +238,10 @@ SELECT asText(NearestApproachInstant(geometry 'Linestring empty', tgeompoint '{P
 SELECT asText(NearestApproachInstant(geometry 'Linestring empty', tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]'));
 SELECT asText(NearestApproachInstant(geometry 'Linestring empty', tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}'));
 
-SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 90)', tgeogpoint 'Point(-90 0)@2001-01-01'));
-SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 90)', tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'));
-SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 90)', tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'));
-SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 90)', tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'));
+SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 60)', tgeogpoint 'Point(-90 0)@2001-01-01'));
+SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 60)', tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'));
+SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 60)', tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'));
+SELECT asText(NearestApproachInstant(geography 'Linestring(90 0,0 60)', tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'));
 
 SELECT asText(NearestApproachInstant(geography 'Linestring empty', tgeogpoint 'Point(-90 0)@2001-01-01'));
 SELECT asText(NearestApproachInstant(geography 'Linestring empty', tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'));
@@ -357,10 +357,10 @@ SELECT round(NearestApproachDistance(tgeompoint '{[Point(1 1 1)@2001-01-01, Poin
 SELECT round(NearestApproachDistance(tgeompoint 'Interp=Step;[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]', geometry 'Linestring Z empty'), 6);
 SELECT round(NearestApproachDistance(tgeompoint 'Interp=Step;{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}', geometry 'Linestring Z empty'), 6);
 
-SELECT round(NearestApproachDistance(tgeogpoint 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 90)'), 6);
-SELECT round(NearestApproachDistance(tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 90)'), 6);
-SELECT round(NearestApproachDistance(tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 90)'), 6);
-SELECT round(NearestApproachDistance(tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 90)'), 6);
+SELECT round(NearestApproachDistance(tgeogpoint 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 60)'), 0);
+SELECT round(NearestApproachDistance(tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 60)'), 0);
+SELECT round(NearestApproachDistance(tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 60)'), 0);
+SELECT round(NearestApproachDistance(tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 60)'), 0);
 
 SELECT round(NearestApproachDistance(tgeogpoint 'Point(-90 0)@2001-01-01', geography 'Linestring empty'), 6);
 SELECT round(NearestApproachDistance(tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring empty'), 6);
@@ -397,10 +397,10 @@ SELECT round(NearestApproachDistance(geometry 'Linestring Z empty', tgeompoint '
 SELECT round(NearestApproachDistance(geometry 'Linestring Z empty', tgeompoint '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]'), 6);
 SELECT round(NearestApproachDistance(geometry 'Linestring Z empty', tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}'), 6);
 
-SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 90)', tgeogpoint 'Point(-90 0)@2001-01-01'), 6);
-SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 90)', tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 6);
-SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 90)', tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'), 6);
-SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 90)', tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'), 6);
+SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 60)', tgeogpoint 'Point(-90 0)@2001-01-01'), 0);
+SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 60)', tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 0);
+SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 60)', tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'), 0);
+SELECT round(NearestApproachDistance(geography 'Linestring(90 0,0 60)', tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'), 0);
 
 SELECT round(NearestApproachDistance(geography 'Linestring empty', tgeogpoint 'Point(-90 0)@2001-01-01'), 6);
 SELECT round(NearestApproachDistance(geography 'Linestring empty', tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 6);
@@ -544,10 +544,10 @@ SELECT round((tgeompoint '{Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Poi
 SELECT round((tgeompoint '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]' |=| geometry 'Linestring Z empty'), 6);
 SELECT round((tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}' |=| geometry 'Linestring Z empty'), 6);
 
-SELECT round((tgeogpoint 'Point(-90 0)@2001-01-01' |=| geography 'Linestring(90 0,0 90)'), 6);
-SELECT round((tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}' |=| geography 'Linestring(90 0,0 90)'), 6);
-SELECT round((tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]' |=| geography 'Linestring(90 0,0 90)'), 6);
-SELECT round((tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}' |=| geography 'Linestring(90 0,0 90)'), 6);
+SELECT round((tgeogpoint 'Point(-90 0)@2001-01-01' |=| geography 'Linestring(90 0,0 60)'), 0);
+SELECT round((tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}' |=| geography 'Linestring(90 0,0 60)'), 0);
+SELECT round((tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]' |=| geography 'Linestring(90 0,0 60)'), 0);
+SELECT round((tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}' |=| geography 'Linestring(90 0,0 60)'), 0);
 
 SELECT round((tgeogpoint 'Point(-90 0)@2001-01-01' |=| geography 'Linestring empty'), 6);
 SELECT round((tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}' |=| geography 'Linestring empty'), 6);
@@ -584,10 +584,10 @@ SELECT round((geometry 'Linestring Z empty' |=| tgeompoint '{Point(1 1 1)@2001-0
 SELECT round((geometry 'Linestring Z empty' |=| tgeompoint '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]'), 6);
 SELECT round((geometry 'Linestring Z empty' |=| tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}'), 6);
 
-SELECT round((geography 'Linestring(90 0,0 90)' |=| tgeogpoint 'Point(-90 0)@2001-01-01'), 6);
-SELECT round((geography 'Linestring(90 0,0 90)' |=| tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 6);
-SELECT round((geography 'Linestring(90 0,0 90)' |=| tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'), 6);
-SELECT round((geography 'Linestring(90 0,0 90)' |=| tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'), 6);
+SELECT round((geography 'Linestring(90 0,0 60)' |=| tgeogpoint 'Point(-90 0)@2001-01-01'), 0);
+SELECT round((geography 'Linestring(90 0,0 60)' |=| tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 0);
+SELECT round((geography 'Linestring(90 0,0 60)' |=| tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'), 0);
+SELECT round((geography 'Linestring(90 0,0 60)' |=| tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'), 0);
 
 SELECT round((geography 'Linestring empty' |=| tgeogpoint 'Point(-90 0)@2001-01-01'), 6);
 SELECT round((geography 'Linestring empty' |=| tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 6);
@@ -702,10 +702,10 @@ SELECT ST_AsTexT(shortestLine(tgeompoint '{Point(1 1 1)@2001-01-01, Point(2 2 2)
 SELECT ST_AsTexT(shortestLine(tgeompoint '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]', geometry 'Linestring Z empty'));
 SELECT ST_AsTexT(shortestLine(tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}', geometry 'Linestring Z empty'));
 
-SELECT ST_AsTexT(shortestLine(tgeogpoint 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 90)'), 1);
-SELECT ST_AsTexT(shortestLine(tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 90)'), 1);
-SELECT ST_AsTexT(shortestLine(tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 90)'), 1);
-SELECT ST_AsTexT(shortestLine(tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 90)'), 1);
+SELECT ST_AsTexT(shortestLine(tgeogpoint 'Point(-90 0)@2001-01-01', geography 'Linestring(90 0,0 60)'), 1);
+SELECT ST_AsTexT(round(shortestLine(tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring(90 0,0 60)')), 6);
+SELECT ST_AsTexT(round(shortestLine(tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]', geography 'Linestring(90 0,0 60)')), 6);
+SELECT ST_AsTexT(round(shortestLine(tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}', geography 'Linestring(90 0,0 60)')), 6);
 
 SELECT ST_AsTexT(shortestLine(tgeogpoint 'Point(-90 0)@2001-01-01', geography 'Linestring empty'));
 SELECT ST_AsTexT(shortestLine(tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}', geography 'Linestring empty'));
@@ -732,10 +732,10 @@ SELECT ST_AsTexT(shortestLine(geometry 'Linestring Z empty', tgeompoint '{Point(
 SELECT ST_AsTexT(shortestLine(geometry 'Linestring Z empty', tgeompoint '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]'));
 SELECT ST_AsTexT(shortestLine(geometry 'Linestring Z empty', tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}'));
 
-SELECT ST_AsTexT(shortestLine(geography 'Linestring(90 0,0 90)', tgeogpoint 'Point(-90 0)@2001-01-01'), 1);
-SELECT ST_AsTexT(shortestLine(geography 'Linestring(90 0,0 90)', tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 1);
-SELECT ST_AsTexT(shortestLine(geography 'Linestring(90 0,0 90)', tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]'), 1);
-SELECT ST_AsTexT(shortestLine(geography 'Linestring(90 0,0 90)', tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}'), 1);
+SELECT ST_AsTexT(shortestLine(geography 'Linestring(90 0,0 60)', tgeogpoint 'Point(-90 0)@2001-01-01'), 1);
+SELECT ST_AsTexT(round(shortestLine(geography 'Linestring(90 0,0 60)', tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}')), 6);
+SELECT ST_AsTexT(round(shortestLine(geography 'Linestring(90 0,0 60)', tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03]')), 6);
+SELECT ST_AsTexT(round(shortestLine(geography 'Linestring(90 0,0 60)', tgeogpoint '{[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03],[Point(90 90)@2001-01-04, Point(90 90)@2001-01-05]}')), 6);
 
 SELECT ST_AsTexT(shortestLine(geography 'Linestring empty', tgeogpoint 'Point(-90 0)@2001-01-01'), 1);
 SELECT ST_AsTexT(shortestLine(geography 'Linestring empty', tgeogpoint '{Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02, Point(-90 0)@2001-01-03}'), 1);

--- a/postgis/liblwgeom/lwgeodetic.c
+++ b/postgis/liblwgeom/lwgeodetic.c
@@ -3392,6 +3392,18 @@ dot_product_side(const POINT3D *p, const POINT3D *q)
 }
 
 /**
+* Utility function for edge_intersects(), true if P lies on the side of the
+* center of the sphere that holds the edge A1/A2.
+*/ /* MEOS */
+static int
+edge_faces_point(const POINT3D *A1, const POINT3D *A2, const POINT3D *P)
+{
+	POINT3D AC;
+	vector_sum(A1, A2, &AC);
+	return dot_product(P, &AC) > 0.0;
+}
+
+/**
 * Returns non-zero if edges A and B interact. The type of interaction is given in the
 * return value with the bitmask elements defined above.
 */
@@ -3471,30 +3483,36 @@ edge_intersects(const POINT3D *A1, const POINT3D *A2, const POINT3D *B1, const P
 		return PIR_NO_INTERACT;
 	}
 
-	/* The rest are all intersects variants... */
-	rv |= PIR_INTERSECTS;
+	/* The rest are all touch variants. An end point on the plane of the */
+	/* other edge lies where the two great circles meet, and the other */
+	/* edge, shorter than half a circle, holds either that point or its */
+	/* antipode: it touches only in the first case. */ /* MEOS */
 
 	/* A touches B */
-	if ( a1_side == 0 )
+	if ( a1_side == 0 && edge_faces_point(B1, B2, A1) )
 	{
 		/* Touches at A1, A2 is on what side? */
+		rv |= PIR_INTERSECTS;
 		rv |= (a2_side < 0 ? PIR_A_TOUCH_RIGHT : PIR_A_TOUCH_LEFT);
 	}
-	else if ( a2_side == 0 )
+	else if ( a2_side == 0 && edge_faces_point(B1, B2, A2) )
 	{
 		/* Touches at A2, A1 is on what side? */
+		rv |= PIR_INTERSECTS;
 		rv |= (a1_side < 0 ? PIR_A_TOUCH_RIGHT : PIR_A_TOUCH_LEFT);
 	}
 
 	/* B touches A */
-	if ( b1_side == 0 )
+	if ( b1_side == 0 && edge_faces_point(A1, A2, B1) )
 	{
 		/* Touches at B1, B2 is on what side? */
+		rv |= PIR_INTERSECTS;
 		rv |= (b2_side < 0 ? PIR_B_TOUCH_RIGHT : PIR_B_TOUCH_LEFT);
 	}
-	else if ( b2_side == 0 )
+	else if ( b2_side == 0 && edge_faces_point(A1, A2, B2) )
 	{
 		/* Touches at B2, B1 is on what side? */
+		rv |= PIR_INTERSECTS;
 		rv |= (b1_side < 0 ? PIR_B_TOUCH_RIGHT : PIR_B_TOUCH_LEFT);
 	}
 


### PR DESCRIPTION
edge_intersects, in the vendored liblwgeom, reads two edges as touching
whenever an end point of one lies on the plane of the other. Such a point
lies where the two great circles meet, and the other edge holds either that
point or its antipode. Where an end point of one edge is the antipode of an
end point of the other, the edges meet at neither, yet edge_intersects reads
a touch, the geodetic distance answers 0 for edges thousands of kilometres
apart, and the shortest line is a segment of no length. A touch counts
only where the end point lies on the side of the center of the sphere that
holds the other edge: an edge is shorter than half a circle, so that side
holds the meeting point and not its antipode. PostGIS master reads the same,
reported as https://trac.osgeo.org/postgis/ticket/6130.

Witness, on master:

  nearestApproachDistance(
    tgeogpoint '[Point(-90 0)@2001-01-01, Point(0 0)@2001-01-02,
      Point(-90 0)@2001-01-03]',
    geography 'Linestring(90 0,0 60)')                             0

where the closest pair is (0 0) and (0 60), 6654072.819 m apart.

064_tpoint_distance and 064_tgeo_distance read the geography
'Linestring(90 0,0 60)' instead of 'Linestring(90 0,0 90)', from which every
point of their trajectories is as far as any other on the sphere, so that its
shortest line and nearest approach instant are a choice among equals, on which
the Windows and the Linux builds differ. The shortest lines both
files print for it round the geography before printing it, as the files' other
geodetic shortest lines do, since the nearest point carries a residue of 1e-14
degrees there, and its distances read in whole metres, since a distance of
millions of metres printed to six decimals reaches the thirteenth significant
digit, where the C libraries of two platforms differ.

Measured:
- Both files answer the nearest approach distance 6654073 m, where master
  answers 0: the distance between the points (0 0) and (0 60) is
  6654072.819 m. From the pole they answer 3347893 m, the distance between
  (90 90) and (0 60) being 3347892.910 m.
- The nearest approach instant is Point(0 0)@2001-01-02 and the shortest line
  LINESTRING(0 0,0 60), each the one answer the input has.
- Edges that share an end point, cross, or touch at an end point of the other
  edge answer 0 before and after.

Why: two edges that share no point are apart, and a distance of 0 between
them is a wrong answer, not a rounding.

