### PR TITLE
State the order of two sets as -1, 0 or 1

### DIFF
--- a/meos/src/temporal/set.c
+++ b/meos/src/temporal/set.c
@@ -1189,7 +1189,14 @@ set_cmp(const Set *s1, const Set *s2)
     else
       result = 0;
   }
-  return result;
+  /* datum_cmp states the order in the sign of its result */
+  if (result == INT_MAX)
+    return INT_MAX;
+  if (result < 0)
+    return -1;
+  if (result > 0)
+    return 1;
+  return 0;
 }
 
 /**

--- a/meos/src/temporal/type_util.c
+++ b/meos/src/temporal/type_util.c
@@ -109,8 +109,8 @@ int64_cmp(int64 l, int64 r)
 }
 
 /**
- * @brief Return -1, 0, or 1 depending on whether the first value is less than, 
- * equal to, or greater than the second one
+ * @brief Return a negative value, 0, or a positive value depending on whether
+ * the first value is less than, equal to, or greater than the second one
  */
 int
 datum_cmp(Datum l, Datum r, MeosType type)

--- a/mobilitydb/test/json/expected/450_jsonbset_tbl.test.out
+++ b/mobilitydb/test/json/expected/450_jsonbset_tbl.test.out
@@ -163,10 +163,16 @@ SELECT COUNT(*) FROM test2 t1, tbl_jsonbset t2 WHERE t1.k = t2.k AND t1.s <> t2.
      0
 (1 row)
 
+SELECT cmp(jsonbset '{"\"a\""}', jsonbset '{"\"z\""}') = -1;
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE cmp(t1.s, t2.s) = -1;
  count 
 -------
-  1136
+  4851
 (1 row)
 
 SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s = t2.s;

--- a/mobilitydb/test/json/queries/450_jsonbset_tbl.test.sql
+++ b/mobilitydb/test/json/queries/450_jsonbset_tbl.test.sql
@@ -101,6 +101,7 @@ SELECT COUNT(*) FROM test2 t1, tbl_jsonbset t2 WHERE t1.k = t2.k AND t1.s <> t2.
 -------------------------------------------------------------------------------
 -- Comparison functions
 
+SELECT cmp(jsonbset '{"\"a\""}', jsonbset '{"\"z\""}') = -1;
 SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE cmp(t1.s, t2.s) = -1;
 SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s = t2.s;
 SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s <> t2.s;

--- a/mobilitydb/test/temporal/expected/001_set.test.out
+++ b/mobilitydb/test/temporal/expected/001_set.test.out
@@ -503,6 +503,12 @@ SELECT dateset '{2001-01-01}' >= dateset '{2001-01-01, 2001-01-02, 2001-01-03}';
  f
 (1 row)
 
+SELECT cmp(textset '{"apple"}', textset '{"zebra"}') = -1;
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT cmp(tstzset '{2001-01-01}', tstzset '{2001-01-01, 2001-01-02, 2001-01-03}') = -1;
  ?column? 
 ----------

--- a/mobilitydb/test/temporal/queries/001_set.test.sql
+++ b/mobilitydb/test/temporal/queries/001_set.test.sql
@@ -171,6 +171,8 @@ SELECT dateset '{2001-01-01}' <= dateset '{2001-01-01, 2001-01-02, 2001-01-03}';
 SELECT dateset '{2001-01-01}' > dateset '{2001-01-01, 2001-01-02, 2001-01-03}';
 SELECT dateset '{2001-01-01}' >= dateset '{2001-01-01, 2001-01-02, 2001-01-03}';
 
+SELECT cmp(textset '{"apple"}', textset '{"zebra"}') = -1;
+
 SELECT cmp(tstzset '{2001-01-01}', tstzset '{2001-01-01, 2001-01-02, 2001-01-03}') = -1;
 SELECT tstzset '{2001-01-01}' = tstzset '{2001-01-01, 2001-01-02, 2001-01-03}';
 SELECT tstzset '{2001-01-01}' <> tstzset '{2001-01-01, 2001-01-02, 2001-01-03}';


### PR DESCRIPTION
set_cmp answers -1, 0 or 1, as its documentation states, and returns the
result of datum_cmp for the first two elements that differ. datum_cmp states
the order in the sign of its result: its arms for text, jsonb and geometry
return that of the comparison function they call, whose magnitude depends on
the C library, glibc's memcmp answering the difference of the first two bytes
that differ. set_cmp reduces the result to its sign where it returns it, as
tinstant_cmp does, leaving the error value INT_MAX as it is, and the
documentation of datum_cmp states the sign it answers.

Witness: on master, with glibc,

  cmp(textset '{"apple"}', textset '{"zebra"}')            -25
  cmp(jsonbset '{"\"a\""}', jsonbset '{"\"z\""}')           -25

where the Windows build of the same code answers -1, and 450_jsonbset_tbl
counts 1136 pairs of distinct jsonb sets with cmp = -1 on Linux and 4851,
99 * 98 / 2, on Windows. With this change both answer -1 and 4851.

Measured:
- 001_set and 450_jsonbset_tbl gain the two witness inputs, cmp(...) = -1,
  and 450_jsonbset_tbl counts 4851.
- set_cmp over two sets of 200 elements that differ in the last one,
  interleaved against master on one core over 20 rounds: 1.009 of master's
  time on text sets (quartiles 0.951 to 1.054) and 0.966 on jsonb sets,
  where master against itself reads 0.954 and 0.998. Reducing the sign inside
  datum_cmp turns each of its tail calls into a call and reads 1.336 on text
  sets.

Why: -1, 0 and 1 is the contract of cmp in SQL and of set_cmp in C, and a
count of the pairs a comparison orders one way is a property of the values,
not of the C library the server links.

