### PR TITLE
Build the planar centroid and boundary of an H3 cell without the geodetic flag

### DIFF
--- a/meos/include/h3/th3index_internal.h
+++ b/meos/include/h3/th3index_internal.h
@@ -85,10 +85,16 @@ typedef enum
 
 /* Point / polygon conversions — bodies in th3index_latlng.c. */
 
-/* Shared helper: build a geodetic SRID 4326 LWPOLY from a libh3
- * CellBoundary and serialise. Primary definition in
- * th3index_latlng.c; also called from th3index_edges.c. */
-extern GSERIALIZED *cell_boundary_to_gs(const CellBoundary *bnd);
+/* Shared helper: build an SRID 4326 polygon, geodetic or planar, from a
+ * libh3 CellBoundary and serialise. Primary definition in
+ * th3index_latlng.c; also called from th3index_edges.c and h3index.c. */
+extern GSERIALIZED *cell_boundary_to_gs(const CellBoundary *bnd,
+  bool geodetic);
+
+/* Geodetic centroid and boundary of a cell, for the shared cell operations
+ * whose temporal results are geodetic. Bodies in th3index_latlng.c. */
+extern GSERIALIZED *h3index_cell_to_geogpoint(H3Index cell);
+extern GSERIALIZED *h3index_cell_to_geog(H3Index cell);
 
 /* Cell-sampling helpers shared between the static-geo walker
  * (h3_geo.c::linestring_to_cells_into) and the temporal densifier

--- a/meos/src/h3/h3index.c
+++ b/meos/src/h3/h3index.c
@@ -544,26 +544,26 @@ datum_h3_latlng_to_cell(Datum point_d, Datum res_d)
 }
 
 /**
- * @brief Return the center point of an H3 cell
+ * @brief Return the geodetic center point of an H3 cell
  */
 Datum
 datum_h3_cell_to_latlng(Datum d)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_H3INDEX_CELL(DatumGetH3Index(d), (Datum) 0);
-  GSERIALIZED *gs = h3index_cell_to_point(DatumGetH3Index(d));
+  GSERIALIZED *gs = h3index_cell_to_geogpoint(DatumGetH3Index(d));
   return PointerGetDatum(gs);
 }
 
 /**
- * @brief Return the boundary of an H3 cell as a geometry
+ * @brief Return the geodetic boundary of an H3 cell
  */
 Datum
 datum_h3_cell_to_boundary(Datum d)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_H3INDEX_CELL(DatumGetH3Index(d), (Datum) 0);
-  GSERIALIZED *gs = h3index_cell_to_boundary(DatumGetH3Index(d));
+  GSERIALIZED *gs = h3index_cell_to_geog(DatumGetH3Index(d));
   return PointerGetDatum(gs);
 }
 

--- a/meos/src/h3/th3index_edges.c
+++ b/meos/src/h3/th3index_edges.c
@@ -58,7 +58,7 @@
  *****************************************************************************/
 
 /**
- * @brief Return the boundary of an H3 directed edge as a geometry
+ * @brief Return the boundary of an H3 directed edge as a geodetic polygon
  */
 GSERIALIZED *
 h3_directed_edge_to_gs_boundary(H3Index edge)
@@ -74,7 +74,7 @@ h3_directed_edge_to_gs_boundary(H3Index edge)
    * quirk. We emit a closed POLYGON too so consumers see a uniform
    * shape, but keep x = lng, y = lat as in
    * `h3index_cell_to_boundary`. */
-  return cell_boundary_to_gs(&bnd);
+  return cell_boundary_to_gs(&bnd, true);
 }
 
 /*****************************************************************************

--- a/meos/src/h3/th3index_latlng.c
+++ b/meos/src/h3/th3index_latlng.c
@@ -104,17 +104,21 @@ h3index_cell_to_point(H3Index cell)
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR, "h3 library error");
     return NULL;
   }
+  /* Planar (non-geodetic) lon/lat point, as the geometry it is */
   return geopoint_make(radsToDegs(ll.lng), radsToDegs(ll.lat), 0.0,
-    false, true, SRID_DEFAULT);
+    false, false, SRID_DEFAULT);
 }
 
 /**
- * @brief Build a geodetic SRID 4326 LWPOLY from a libh3 CellBoundary
- * and serialise it. The ring is closed by repeating vertex 0. Shared
- * between cell and directed-edge boundary adapters.
+ * @brief Return an SRID 4326 polygon built from a libh3 CellBoundary,
+ * geodetic or planar as its caller states
+ * @details The ring closes by repeating vertex 0. The cell and the
+ * directed-edge boundary adapters share it.
+ * @param[in] bnd Boundary
+ * @param[in] geodetic True when the polygon is geodetic
  */
 GSERIALIZED *
-cell_boundary_to_gs(const CellBoundary *bnd)
+cell_boundary_to_gs(const CellBoundary *bnd, bool geodetic)
 {
   POINTARRAY *pa = ptarray_construct_empty(LW_FALSE, LW_FALSE,
     bnd->numVerts + 1);
@@ -137,7 +141,7 @@ cell_boundary_to_gs(const CellBoundary *bnd)
 
   LWPOLY *poly = lwpoly_construct_empty(SRID_DEFAULT, LW_FALSE, LW_FALSE);
   lwpoly_add_ring(poly, pa);
-  lwgeom_set_geodetic(lwpoly_as_lwgeom(poly), LW_TRUE);
+  lwgeom_set_geodetic(lwpoly_as_lwgeom(poly), geodetic);
   GSERIALIZED *result = geo_serialize(lwpoly_as_lwgeom(poly));
   lwpoly_free(poly);
   return result;
@@ -158,7 +162,40 @@ h3index_cell_to_boundary(H3Index cell)
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR, "h3 library error");
     return NULL;
   }
-  return cell_boundary_to_gs(&bnd);
+  return cell_boundary_to_gs(&bnd, false);
+}
+
+/**
+ * @brief Return the centroid of an H3 cell as a geodetic point
+ * @param[in] cell H3 cell
+ */
+GSERIALIZED *
+h3index_cell_to_geogpoint(H3Index cell)
+{
+  LatLng ll;
+  if (cellToLatLng(cell, &ll) != E_SUCCESS)
+  {
+    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR, "h3 library error");
+    return NULL;
+  }
+  return geopoint_make(radsToDegs(ll.lng), radsToDegs(ll.lat), 0.0,
+    false, true, SRID_DEFAULT);
+}
+
+/**
+ * @brief Return the boundary of an H3 cell as a geodetic polygon
+ * @param[in] cell H3 cell
+ */
+GSERIALIZED *
+h3index_cell_to_geog(H3Index cell)
+{
+  CellBoundary bnd;
+  if (cellToBoundary(cell, &bnd) != E_SUCCESS)
+  {
+    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR, "h3 library error");
+    return NULL;
+  }
+  return cell_boundary_to_gs(&bnd, true);
 }
 
 /*****************************************************************************
@@ -460,11 +497,19 @@ th3index_to_tgeogpoint(const Temporal *temp)
 /*****************************************************************************
  * cellToPoint (planar output, SRID 4326 overload)
  *
- * Both overloads share the same static adapter `h3index_cell_to_point`,
- * which emits an SRID-4326 point. The geography-vs-geometry nature
- * of the result is disambiguated at the lifting layer via the
- * `restype` setting — downstream consumers see the intended type.
+ * The planar trajectory lifts the planar centroid `h3index_cell_to_point`
+ * answers, and the geodetic trajectory above lifts the geodetic centroid
+ * `h3index_cell_to_geogpoint` answers through the shared cell operations.
  *****************************************************************************/
+
+/**
+ * @brief Return the planar centroid of an H3 cell
+ */
+static Datum
+datum_h3_cell_to_geompoint(Datum d)
+{
+  return PointerGetDatum(h3index_cell_to_point(DatumGetH3Index(d)));
+}
 
 /**
  * @ingroup meos_h3_latlng
@@ -480,7 +525,7 @@ th3index_to_tgeompoint(const Temporal *temp)
 
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
-  lfinfo.func = (varfunc) &datum_h3_cell_to_latlng;
+  lfinfo.func = (varfunc) &datum_h3_cell_to_geompoint;
   lfinfo.numparam = 0;
   lfinfo.argtype[0] = T_TH3INDEX;
   lfinfo.restype = T_TGEOMPOINT;

--- a/mobilitydb/test/h3/expected/252_h3index_ops.test.out
+++ b/mobilitydb/test/h3/expected/252_h3index_ops.test.out
@@ -92,6 +92,27 @@ SELECT ST_Contains(
  t
 (1 row)
 
+SELECT cellToBoundary(h3index '871fa44a8ffffff')
+  && ST_MakeEnvelope(4, 50, 5, 51, 4326);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT ST_Intersects(cellToBoundary(h3index '871fa44a8ffffff'),
+  ST_MakeEnvelope(4, 50, 5, 51, 4326));
+ st_intersects 
+---------------
+ t
+(1 row)
+
+SELECT cellToPoint(h3index '871fa44a8ffffff')
+  && ST_MakeEnvelope(4, 50, 5, 51, 4326);
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT geoToH3Cell(cellToPoint(h3index '871fa44a8ffffff'), 7)
   = h3index '871fa44a8ffffff';
  ?column? 
@@ -127,6 +148,20 @@ SELECT cellArea(h3index '871fa44a8ffffff')
 
 SELECT ST_AsBinary(cellToBoundary(h3index '871fa44a8ffffff'))
   = ST_AsBinary(getValue(cellToBoundary(th3index '871fa44a8ffffff@2001-01-01'))::geometry);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT ST_AsBinary(startValue(tgeompoint(th3index '871fa44a8ffffff@2001-01-01')))
+  = ST_AsBinary(cellToPoint(h3index '871fa44a8ffffff'));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT startValue(tgeompoint(th3index '871fa44a8ffffff@2001-01-01'))
+  && ST_MakeEnvelope(4, 50, 5, 51, 4326);
  ?column? 
 ----------
  t

--- a/mobilitydb/test/h3/queries/252_h3index_ops.test.sql
+++ b/mobilitydb/test/h3/queries/252_h3index_ops.test.sql
@@ -80,6 +80,15 @@ SELECT ST_Contains(
   cellToBoundary(h3index '871fa44a8ffffff'),
   cellToPoint(h3index '871fa44a8ffffff'));
 
+-- The boundary and the centroid are planar geometries, so the box of a
+-- geometry around the cell overlaps them
+SELECT cellToBoundary(h3index '871fa44a8ffffff')
+  && ST_MakeEnvelope(4, 50, 5, 51, 4326);
+SELECT ST_Intersects(cellToBoundary(h3index '871fa44a8ffffff'),
+  ST_MakeEnvelope(4, 50, 5, 51, 4326));
+SELECT cellToPoint(h3index '871fa44a8ffffff')
+  && ST_MakeEnvelope(4, 50, 5, 51, 4326);
+
 -- The cell containing the centroid is the cell itself
 SELECT geoToH3Cell(cellToPoint(h3index '871fa44a8ffffff'), 7)
   = h3index '871fa44a8ffffff';
@@ -111,5 +120,12 @@ SELECT cellArea(h3index '871fa44a8ffffff')
 
 SELECT ST_AsBinary(cellToBoundary(h3index '871fa44a8ffffff'))
   = ST_AsBinary(getValue(cellToBoundary(th3index '871fa44a8ffffff@2001-01-01'))::geometry);
+
+-- The planar trajectory holds the planar centroid, so the box of a geometry
+-- around the cell overlaps it
+SELECT ST_AsBinary(startValue(tgeompoint(th3index '871fa44a8ffffff@2001-01-01')))
+  = ST_AsBinary(cellToPoint(h3index '871fa44a8ffffff'));
+SELECT startValue(tgeompoint(th3index '871fa44a8ffffff@2001-01-01'))
+  && ST_MakeEnvelope(4, 50, 5, 51, 4326);
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
cellToPoint(h3index) and cellToBoundary(h3index) return geometry, and
tgeompoint(th3index) a temporal geometry point, so their values are planar
lon/lat values in SRID 4326. h3index_cell_to_point and
h3index_cell_to_boundary build planar values, as quadbin_cell_to_geompoint
does for a QUADBIN cell.

The witness: cellToBoundary(h3index '871fa44a8ffffff') &&
ST_MakeEnvelope(4, 50, 5, 51, 4326), for a cell whose centre lies at
POINT(4.297401 50.8043), answers true on this branch, as do ST_Intersects over the
same pair, cellToPoint(h3index '871fa44a8ffffff') && the same envelope, and
startValue(tgeompoint(th3index '871fa44a8ffffff@2001-01-01')) && the same
envelope. On master the first, third and fourth answer false, ST_Intersects
raises "gbox_overlaps: cannot compare geodetic and non-geodetic boxes", and
Box2D(cellToBoundary(h3index '871fa44a8ffffff')) answers
BOX(0.63004319644606 0.047161315818207,0.630345555486897 0.047550315065839),
geocentric coordinates rather than the longitude and latitude of the cell.

The model: whether a spatial value is geodetic is part of its type, and
PostGIS reads the box of a value flagged geodetic as a geocentric box. A
function that returns geometry or tgeompoint answers planar values, and one
that returns geography, tgeogpoint or tgeography answers geodetic ones, as
QUADBIN, whose values are all planar, and S2, whose cell values are all
geodetic, already do.

The shared cell operations of H3 answer the geodetic values their temporal
geography results hold: the centroid and boundary slots read
h3index_cell_to_geogpoint and h3index_cell_to_geog, the twins of
s2cell_cell_to_geogpoint and s2cell_cell_to_geog, and the planar trajectory
lifts the planar centroid through a slot of its own. cell_boundary_to_gs
takes the flag from its caller, and the boundary of a directed edge, whose
temporal result is a geography, stays geodetic.

Measured on the head of the branch: every regression file of the PostgreSQL
18 suite answers what its expected output states, 252_h3index_ops carrying
the 35 lines of its five new cases and no other difference; the 60 invocations of the meos/test step of meos.yml exit with
status 0, as does threaded_test under ThreadSanitizer; the extension, the
extension without families and libmeos build with no compiler warning in the
4 changed files; cppcheck reports 152 findings on master and 152 on the
branch; the 7 smoke suites answer their 140, 218, 192, 129, 455, 189 and 23
results with no validation warning; the MSYS2 UCRT64 libmeos build of the
meos-windows job completes; and of the answers of the 45 coverage
instruments, the line that differs from master is the wall clock.

