### PR TITLE
Measure the distance of curves at their nearest points and draw it from the first geometry

### DIFF
--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -697,6 +697,97 @@ int main(void)
   assert(dist_ok == 41);
   meos_errno_reset();
 
+  /* The distance between curves is checked on the cases PostGIS gives its
+   * own unit tests for the distance fixes of its 3.6 line (ticket 5989): a
+   * point outside a curve polygon beside its arc, a point beside the arc of a
+   * compound-curve polygon at projected coordinates, a multisurface of
+   * compound curves against a polygon, an arc inside the circle of a
+   * semicircle, and a closed circle against that semicircle, each to the
+   * tolerance its test gives. The last pair is a segment whose line crosses
+   * the circle of an arc away from the arc: the nearest point of the arc is
+   * its end (-51.606 11.029), 21.134199125017 from the segment, which a
+   * stroke of the arc into a million points gives too. With the crossings of
+   * the line built from the end of the segment nearest the centre of the arc,
+   * they lie off the circle and the pair reads 0 */
+  static const struct { const char *a, *b; double dist, tol; } curve_dist[] =
+  {
+    {"CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(0 0,-1 5,0 10),"
+       "(0 10,-10 10,-10 0,0 0)))", "POINT(-0.5 5)", 0.5, 1e-6},
+    {"CURVEPOLYGON(COMPOUNDCURVE((129296 142584,94722 100435,91618 97138,"
+       "57306 60686,26874 28357,13059 34228,14572 65506,14593 65948,"
+       "14616 66389),CIRCULARSTRING(14616 66389,17955 101124,24417 135415,"
+       "24655 136418,24895 137421),(24895 137421,25472 139809,19354 141285,"
+       "0 0,148000 142000,129296 142584)))", "POINT(19925 112376)", 199.655,
+       1e-3},
+    {"MULTISURFACE(CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING("
+       "25493681.3085 6678739.6419,25493637.8256 6678776.2541,"
+       "25493599.9716 6678818.6604),(25493599.9716 6678818.6604,"
+       "25493583.8816 6678839.494,25493590.9591 6678844.9594,"
+       "25493566.9698 6678851.9051,25493526.5793 6678861.0985,"
+       "25493487.3853 6678868.2546,25493447.392 6678871.7846,"
+       "25493429.5033 6678876.6846,25493435.0147 6678857.4594,"
+       "25493454.9254 6678821.6192,25493452.4867 6678816.1292,"
+       "25493402.3226 6678828.2153,25493354.7526 6678837.8291,"
+       "25493349.0217 6678838.9873,25493310.914 6678843.6926,"
+       "25493306.3784 6678859.9295,25493294.1011 6678858.7864,"
+       "25493169.9028 6678847.2212,25493127.549 6678843.2773,"
+       "25493057.8888 6678834.6763,25493017.4547 6678826.7261,"
+       "25492928.2395 6678821.5524,25492909.1067 6678795.0681,"
+       "25492946.9544 6678794.8193,25492967.1292 6678794.6866,"
+       "25493010.8878 6678795.9163,25493111.5564 6678804.3109,"
+       "25493113.4069 6678799.5694,25493134.2375 6678806.0729),"
+       "CIRCULARSTRING(25493134.2375 6678806.0729,25493223.038 6678812.0533,"
+       "25493311.4919 6678802.1948,25493317.3589 6678800.9679,"
+       "25493323.2107 6678799.6707),(25493323.2107 6678799.6707,"
+       "25493362.6615 6678792.3924,25493364.6948 6678785.173,"
+       "25493375.0512 6678781.6008,25493404.9736 6678771.2798),"
+       "CIRCULARSTRING(25493404.9736 6678771.2798,25493486.8049 6678737.6728,"
+       "25493566.8862 6678700.0859),(25493566.8862 6678700.0859,"
+       "25493574.903 6678714.0761,25493600.2214 6678702.8803,"
+       "25493654.1114 6678670.2493,25493669.7219 6678659.2147,"
+       "25493677.0288 6678653.353,25493684.6468 6678648.4119,"
+       "25493724.0447 6678623.7638,25493800.1925 6678583.5847,"
+       "25493805.6261 6678586.1292,25493811.9258 6678582.3016,"
+       "25493812.8413 6678583.0522,25493846.581 6678558.6541,"
+       "25493884.2653 6678531.6272,25493900.9168 6678580.1258,"
+       "25493830.7852 6678630.9518,25493789.0848 6678661.2736,"
+       "25493746.1612 6678692.485,25493686.5413 6678735.8369,"
+       "25493681.3085 6678739.6419))))",
+     "POLYGON((25492929.752797972 6678919.124091367,"
+       "25493008.675235115 6678876.783133076,"
+       "25493098.02917443 6678854.33589699,"
+       "25493139.669701554 6678977.913508233,"
+       "25493122.946292613 6679011.427315322,"
+       "25493050.53388224 6679068.791126598,"
+       "25493140.33593199 6679140.958135231,"
+       "25492931.688606273 6679401.2946243705,"
+       "25492799.289171 6679295.949040241,"
+       "25492651.5177725 6679115.144800108,"
+       "25492929.752797972 6678919.124091367))", 14.5, 1.0},
+    {"CIRCULARSTRING(0 0.5,-0.3 0.5,0 0.6)", "CIRCULARSTRING(-1 0,0 1,1 0)",
+       0.271798, 1e-6},
+    {"CIRCULARSTRING(-2 -0.1,1.5 -0.1,-2 -0.1)",
+       "CIRCULARSTRING(-1 0,0 1,1 0)", 0.480742, 1e-4},
+    {"LINESTRING(-68.783742 -2.494091,-60.061866 -9.05758)",
+       "CIRCULARSTRING(-44.366 20.140,-46.412 17.269,-51.606 11.029)",
+       21.134199125017, 1e-9},
+  };
+  int curve_ok = 0;
+  for (size_t i = 0; i < sizeof curve_dist / sizeof curve_dist[0]; i++)
+  {
+    GSERIALIZED *ga = geom_in(curve_dist[i].a, -1);
+    GSERIALIZED *gb = geom_in(curve_dist[i].b, -1);
+    assert(ga != NULL); assert(gb != NULL);
+    assert(fabs(geom_distance2d(ga, gb) - curve_dist[i].dist) <=
+      curve_dist[i].tol);
+    curve_ok++;
+    free(ga); free(gb);
+  }
+  printf("the distance between curves is the value PostGIS's tests give, or "
+    "the closed form, on %d pairs\n", curve_ok);
+  assert(curve_ok == 6);
+  meos_errno_reset();
+
   /* A GEOMETRYCOLLECTION is the union of its components, so what it shares
    * with another geometry is the union of what the components share. The
    * overlay reads it that way now, which is how the matrix has always read a

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -708,7 +708,10 @@ int main(void)
    * its end (-51.606 11.029), 21.134199125017 from the segment, which a
    * stroke of the arc into a million points gives too. With the crossings of
    * the line built from the end of the segment nearest the centre of the arc,
-   * they lie off the circle and the pair reads 0 */
+   * they lie off the circle and the pair reads 0. The seventh pair is a
+   * segment and an arc whose end (1 50) lies at distance 1 from the segment,
+   * which reads 50.01 while the kernel measures only the ends of the segment
+   * against the arc */
   static const struct { const char *a, *b; double dist, tol; } curve_dist[] =
   {
     {"CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(0 0,-1 5,0 10),"
@@ -771,6 +774,8 @@ int main(void)
     {"LINESTRING(-68.783742 -2.494091,-60.061866 -9.05758)",
        "CIRCULARSTRING(-44.366 20.140,-46.412 17.269,-51.606 11.029)",
        21.134199125017, 1e-9},
+    {"LINESTRING(0 -100,0 100)", "CIRCULARSTRING(40 60,20 52,1 50)", 1.0,
+       0.0},
   };
   int curve_ok = 0;
   for (size_t i = 0; i < sizeof curve_dist / sizeof curve_dist[0]; i++)
@@ -785,7 +790,7 @@ int main(void)
   }
   printf("the distance between curves is the value PostGIS's tests give, or "
     "the closed form, on %d pairs\n", curve_ok);
-  assert(curve_ok == 6);
+  assert(curve_ok == 7);
   meos_errno_reset();
 
   /* The shortest line between two geometries runs from the first to the

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -788,6 +788,56 @@ int main(void)
   assert(curve_ok == 6);
   meos_errno_reset();
 
+  /* The shortest line between two geometries runs from the first to the
+   * second, whichever of the two a curve kernel measures first: the ring of a
+   * curve polygon against a line, a point against the nearest end of an arc
+   * in either order, a segment against the end of an arc, a point arc at the
+   * centre of another arc, an arc against a straight arc and against a point
+   * arc, and two point arcs. The last three pairs are the same shapes in the
+   * order the kernels already record them, which the line keeps */
+  static const struct { const char *a, *b, *line; } curve_line[] =
+  {
+    {"CURVEPOLYGON(CIRCULARSTRING(0 0,1 1,2 0,1 -1,0 0))",
+       "LINESTRING(1 3,2 3)", "LINESTRING(1 1,1 3)"},
+    {"POINT(3 -1)", "CIRCULARSTRING(0 0,1 1,2 0)", "LINESTRING(3 -1,2 0)"},
+    {"CIRCULARSTRING(0 0,1 1,2 0)", "POINT(3 -1)", "LINESTRING(2 0,3 -1)"},
+    {"LINESTRING(1 2,3 2)",
+       "CIRCULARSTRING(-1 0,-0.70710678 0.70710678,0 1)",
+       "LINESTRING(1 2,0 1)"},
+    {"CIRCULARSTRING(1 0,1 0,1 0)", "CIRCULARSTRING(0 0,1 1,2 0)",
+       "LINESTRING(1 0,0 0)"},
+    {"CIRCULARSTRING(0 0,1 1,2 0)", "CIRCULARSTRING(5 0,6 0,7 0)",
+       "LINESTRING(2 0,5 0)"},
+    {"CIRCULARSTRING(0 0,1 1,2 0)", "CIRCULARSTRING(5 0,5 0,5 0)",
+       "LINESTRING(2 0,5 0)"},
+    {"CIRCULARSTRING(0 0,0 0,0 0)", "CIRCULARSTRING(5 0,5 0,5 0)",
+       "LINESTRING(0 0,5 0)"},
+    {"LINESTRING(1 3,2 3)",
+       "CURVEPOLYGON(CIRCULARSTRING(0 0,1 1,2 0,1 -1,0 0))",
+       "LINESTRING(1 3,1 1)"},
+    {"CIRCULARSTRING(5 0,6 0,7 0)", "CIRCULARSTRING(0 0,1 1,2 0)",
+       "LINESTRING(5 0,2 0)"},
+    {"CIRCULARSTRING(5 0,5 0,5 0)", "CIRCULARSTRING(0 0,1 1,2 0)",
+       "LINESTRING(5 0,2 0)"},
+  };
+  int line_ok = 0;
+  for (size_t i = 0; i < sizeof curve_line / sizeof curve_line[0]; i++)
+  {
+    GSERIALIZED *ga = geom_in(curve_line[i].a, -1);
+    GSERIALIZED *gb = geom_in(curve_line[i].b, -1);
+    assert(ga != NULL); assert(gb != NULL);
+    GSERIALIZED *sl = geom_shortestline2d(ga, gb);
+    assert(sl != NULL);
+    char *wkt = geo_as_text(sl, 6);
+    assert(strcmp(wkt, curve_line[i].line) == 0);
+    line_ok++;
+    free(wkt); free(sl); free(ga); free(gb);
+  }
+  printf("the shortest line runs from the first geometry to the second on %d "
+    "pairs of curves\n", line_ok);
+  assert(line_ok == 11);
+  meos_errno_reset();
+
   /* A GEOMETRYCOLLECTION is the union of its components, so what it shares
    * with another geometry is the union of what the components share. The
    * overlay reads it that way now, which is how the matrix has always read a

--- a/mobilitydb/test/geo/expected/070_tgeo_spatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/070_tgeo_spatialrels_tbl.test.out
@@ -337,13 +337,13 @@ SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE aTouches(t1.temp, 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE eDwithin(g, temp, 10);
  count 
 -------
-  4802
+  4803
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eDwithin(temp, g, 10);
  count 
 -------
-  4802
+  4803
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE eDwithin(t1.temp, t2.temp, 10);
@@ -355,13 +355,13 @@ SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE eDwithin(t1.temp, 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry_seq WHERE eDwithin(g, seq, 10);
  count 
 -------
-  4292
+  4296
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry_seqset WHERE eDwithin(g, ss, 10);
  count 
 -------
-  9563
+  9562
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry_seq t1, tbl_tgeometry t2 WHERE eDwithin(t1.seq, t2.temp, 10);

--- a/mobilitydb/test/geo/expected/070_tgeo_spatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/070_tgeo_spatialrels_tbl.test.out
@@ -337,13 +337,13 @@ SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE aTouches(t1.temp, 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE eDwithin(g, temp, 10);
  count 
 -------
-  4803
+  4804
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eDwithin(temp, g, 10);
  count 
 -------
-  4803
+  4804
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE eDwithin(t1.temp, t2.temp, 10);
@@ -361,7 +361,7 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry_seq WHERE eDwithin(g, seq, 10);
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry_seqset WHERE eDwithin(g, ss, 10);
  count 
 -------
-  9562
+  9563
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry_seq t1, tbl_tgeometry t2 WHERE eDwithin(t1.seq, t2.temp, 10);

--- a/postgis/liblwgeom/liblwgeom_internal.h
+++ b/postgis/liblwgeom/liblwgeom_internal.h
@@ -456,13 +456,15 @@ int lw_arc_frame(const POINT2D *A1, const POINT2D *A2, const POINT2D *A3, LW_ARC
 int lw_pt_in_seg(const POINT2D *P, const POINT2D *A1, const POINT2D *A2);
 int lw_pt_in_arc(const POINT2D *P, const POINT2D *A1, const POINT2D *A2, const POINT2D *A3);
 int lw_arc_is_pt(const POINT2D *A1, const POINT2D *A2, const POINT2D *A3);
+int lw_pt_on_segment(const POINT2D* p1, const POINT2D* p2, const POINT2D* p);
 double lw_seg_length(const POINT2D *A1, const POINT2D *A2);
 double lw_arc_length(const POINT2D *A1, const POINT2D *A2, const POINT2D *A3);
 int pt_in_ring_2d(const POINT2D *p, const POINTARRAY *ring);
 int ptarray_contains_point(const POINTARRAY *pa, const POINT2D *pt);
 int ptarrayarc_contains_point(const POINTARRAY *pa, const POINT2D *pt);
 int ptarray_contains_point_partial(const POINTARRAY *pa, const POINT2D *pt, int check_closed, int *winding_number);
-int ptarrayarc_contains_point_partial(const POINTARRAY *pa, const POINT2D *pt, int check_closed, int *winding_number);
+int ptarray_raycast_intersections(const POINTARRAY *pa, const POINT2D *p, int *on_boundary);
+int ptarrayarc_raycast_intersections(const POINTARRAY *pa, const POINT2D *p, int *on_boundary);
 int lwcompound_contains_point(const LWCOMPOUND *comp, const POINT2D *pt);
 int lwgeom_contains_point(const LWGEOM *geom, const POINT2D *pt);
 

--- a/postgis/liblwgeom/lwalgorithm.c
+++ b/postgis/liblwgeom/lwalgorithm.c
@@ -107,25 +107,11 @@ lw_pt_in_seg(const POINT2D *P, const POINT2D *A1, const POINT2D *A2)
 }
 
 int
-lw_pt_on_segment(const POINT2D* p1, const POINT2D* p2, const POINT2D* p)
+lw_pt_on_segment(const POINT2D* A1, const POINT2D* A2, const POINT2D* P)
 {
-    // Check if the point is within the bounding box of the segment
-    if (p->x < FP_MIN(p1->x, p2->x) || p->x > FP_MAX(p1->x, p2->x) ||
-        p->y < FP_MIN(p1->y, p2->y) || p->y > FP_MAX(p1->y, p2->y))
-    {
-        return LW_FALSE;
-    }
-
-    // Check for collinearity using the 2D cross-product.
-    // (p.y - p1.y) * (p2.x - p1.x) - (p.x - p1.x) * (p2.y - p1.y)
-    double cross_product = (p->y - p1->y) * (p2->x - p1->x) - (p->x - p1->x) * (p2->y - p1->y);
-
-    if (fabs(cross_product) < DBL_EPSILON)
-    {
-        return LW_TRUE; // Point is collinear and within the bounding box
-    }
-
-    return LW_TRUE;
+	int side = lw_segment_side(A1, A2, P);
+	if (side != 0) return LW_FALSE;
+	return lw_pt_in_seg(P, A1, A2);
 }
 
 /**

--- a/postgis/liblwgeom/lwalgorithm.c
+++ b/postgis/liblwgeom/lwalgorithm.c
@@ -90,7 +90,9 @@ lw_seg_length(const POINT2D *A1, const POINT2D *A2)
 int
 lw_pt_in_arc(const POINT2D *P, const POINT2D *A1, const POINT2D *A2, const POINT2D *A3)
 {
-	return lw_segment_side(A1, A3, A2) == lw_segment_side(A1, A3, P);
+	int pt_side = lw_segment_side(A1, A3, P);
+	int arc_side = lw_segment_side(A1, A3, A2);
+	return pt_side == 0 || pt_side == arc_side;
 }
 
 /**
@@ -102,6 +104,28 @@ lw_pt_in_seg(const POINT2D *P, const POINT2D *A1, const POINT2D *A2)
 {
 	return ((A1->x <= P->x && P->x < A2->x) || (A1->x >= P->x && P->x > A2->x)) ||
 	       ((A1->y <= P->y && P->y < A2->y) || (A1->y >= P->y && P->y > A2->y));
+}
+
+int
+lw_pt_on_segment(const POINT2D* p1, const POINT2D* p2, const POINT2D* p)
+{
+    // Check if the point is within the bounding box of the segment
+    if (p->x < FP_MIN(p1->x, p2->x) || p->x > FP_MAX(p1->x, p2->x) ||
+        p->y < FP_MIN(p1->y, p2->y) || p->y > FP_MAX(p1->y, p2->y))
+    {
+        return LW_FALSE;
+    }
+
+    // Check for collinearity using the 2D cross-product.
+    // (p.y - p1.y) * (p2.x - p1.x) - (p.x - p1.x) * (p2.y - p1.y)
+    double cross_product = (p->y - p1->y) * (p2->x - p1->x) - (p->x - p1->x) * (p2->y - p1->y);
+
+    if (fabs(cross_product) < DBL_EPSILON)
+    {
+        return LW_TRUE; // Point is collinear and within the bounding box
+    }
+
+    return LW_TRUE;
 }
 
 /**

--- a/postgis/liblwgeom/lwcompound.c
+++ b/postgis/liblwgeom/lwcompound.c
@@ -184,63 +184,49 @@ int lwgeom_contains_point(const LWGEOM *geom, const POINT2D *pt)
 	return LW_FAILURE;
 }
 
+/*
+ * Use a ray-casting count to determine if the point
+ * is inside or outside of the compound curve. Ray-casting
+ * is run against each component of the overall arc, and
+ * the even/odd test run against the total of all components.
+ * Returns LW_INSIDE / LW_BOUNDARY / LW_OUTSIDE
+ */
 int
 lwcompound_contains_point(const LWCOMPOUND *comp, const POINT2D *pt)
 {
-	uint32_t i;
-	LWLINE *lwline;
-	LWCIRCSTRING *lwcirc;
-	int wn = 0;
-	int winding_number = 0;
-	int result;
+	int intersections = 0;
 
-	for ( i = 0; i < comp->ngeoms; i++ )
+	if (lwgeom_is_empty(lwcompound_as_lwgeom(comp)))
+		return LW_OUTSIDE;
+
+	for (uint32_t j = 0; j < comp->ngeoms; j++)
 	{
-		LWGEOM *lwgeom = comp->geoms[i];
-		if ( lwgeom->type == LINETYPE )
+		int on_boundary = LW_FALSE;
+		const LWGEOM *sub = comp->geoms[j];
+		if (sub->type == LINETYPE)
 		{
-			lwline = lwgeom_as_lwline(lwgeom);
-			if ( comp->ngeoms == 1 )
-			{
-				return ptarray_contains_point(lwline->points, pt);
-			}
-			else
-			{
-				/* Don't check closure while doing p-i-p test */
-				result = ptarray_contains_point_partial(lwline->points, pt, LW_FALSE, &winding_number);
-			}
+			LWLINE *lwline = lwgeom_as_lwline(sub);
+			intersections += ptarray_raycast_intersections(lwline->points, pt, &on_boundary);
+		}
+		else if (sub->type == CIRCSTRINGTYPE)
+		{
+			LWCIRCSTRING *lwcirc = lwgeom_as_lwcircstring(sub);
+			intersections += ptarrayarc_raycast_intersections(lwcirc->points, pt, &on_boundary);
 		}
 		else
 		{
-			lwcirc = lwgeom_as_lwcircstring(lwgeom);
-			if ( ! lwcirc ) {
-				lwerror("Unexpected component of type %s in compound curve", lwtype_name(lwgeom->type));
-				return 0;
-			}
-			if ( comp->ngeoms == 1 )
-			{
-				return ptarrayarc_contains_point(lwcirc->points, pt);
-			}
-			else
-			{
-				/* Don't check closure while doing p-i-p test */
-				result = ptarrayarc_contains_point_partial(lwcirc->points, pt, LW_FALSE, &winding_number);
-			}
+			lwerror("%s: unsupported type %s", __func__, lwtype_name(sub->type));
+			return LW_OUTSIDE; /* MEOS */
 		}
-
-		/* Propagate boundary condition */
-		if ( result == LW_BOUNDARY )
+		if (on_boundary)
 			return LW_BOUNDARY;
-
-		wn += winding_number;
 	}
 
-	/* Outside */
-	if (wn == 0)
-		return LW_OUTSIDE;
-
-	/* Inside */
-	return LW_INSIDE;
+	/*
+	 * Odd number of intersections means inside.
+	 * Even means outside.
+	 */
+	return (intersections % 2) ? LW_INSIDE : LW_OUTSIDE;
 }
 
 LWCOMPOUND *

--- a/postgis/liblwgeom/measures.c
+++ b/postgis/liblwgeom/measures.c
@@ -2293,105 +2293,160 @@ End of New faster distance calculations
 Functions in common for Brute force and new calculation
 --------------------------------------------------------------------------------------------------------------*/
 
-/**
-lw_dist2d_comp from p to line A->B
-This one is now sending every occasion to lw_dist2d_pt_pt
-Before it was handling occasions where r was between 0 and 1 internally
-and just returning the distance without identifying the points.
-To get this points it was necessary to change and it also showed to be about 10%faster.
-*/
 int
-lw_dist2d_pt_seg(const POINT2D *p, const POINT2D *A, const POINT2D *B, DISTPTS *dl)
+lw_dist2d_pt_seg(const POINT2D *C, const POINT2D *A, const POINT2D *B, DISTPTS *dl)
 {
-	double r;
-
-	LWDEBUG(2, "lw_dist2d_pt_seg called");
-
-	/*if start==end, then use pt distance */
-	if ((A->x == B->x) && (A->y == B->y))
-	{
-		LWDEBUG(2, "lw_dist2d_pt_seg found first and last segment points being the same");
-		return lw_dist2d_pt_pt(p, A, dl);
-	}
-
+	POINT2D P;
+	int is_vertical   = (A->x == B->x);
+	int is_horizontal = (A->y == B->y);
 
 	/*
-	 * otherwise, we use comp.graphics.algorithms
-	 * Frequently Asked Questions method
+	 * If A == B, then use pt-pt distance
+	 */
+	if (is_vertical && is_horizontal)
+		return lw_dist2d_pt_pt(C, A, dl);
+
+	/*
+	 * We use comp.graphics.algorithms Frequently Asked Questions method
 	 *
-	 *  (1)        AC dot AB
-	 *         r = ---------
-	 *              ||AB||^2
-	 *	r has the following meaning:
-	 *	r=0 P = A
-	 *	r=1 P = B
-	 *	r<0 P is on the backward extension of AB
-	 *	r>1 P is on the forward extension of AB
-	 *	0<r<1 P is interior to AB
+	 *  Let the point be C (Cx,Cy) and the line be AB (Ax,Ay) to (Bx,By).
+	 *  Let P be the point of perpendicular projection of C on AB.  The parameter
+	 *  r, which indicates P's position along AB, is computed by the dot product
+	 *  of AC and AB divided by the square of the length of AB:
+	 *
+	 *  (1)     AC dot AB
+	 *      r = ---------
+	 *          ||AB||^2
+	 *
+	 *  The length of a line segment
+	 *
+	 *      L = sqrt( (Bx-Ax)^2 + (By-Ay)^2 )
+	 *
+	 *  So (1) expands to:
+	 *
+	 *          (Cx-Ax)(Bx-Ax) + (Cy-Ay)(By-Ay)
+	 *      r = -------------------------------
+	 *                        L^2
+	 *
+	 *  r has the following meaning:
+	 *
+	 *      r=0      P = A
+	 *      r=1      P = B
+	 *      r<0      P is on the backward extension of AB
+	 *      r>1      P is on the forward extension of AB
+	 *      0<r<1    P is interior to AB
+	 *
 	 */
 
-	r = ((p->x - A->x) * (B->x - A->x) + (p->y - A->y) * (B->y - A->y)) /
-	    ((B->x - A->x) * (B->x - A->x) + (B->y - A->y) * (B->y - A->y));
+	double dx = B->x - A->x;
+	double dy = B->y - A->y;
+	double L2 = (dx*dx) + (dy*dy);
 
-	LWDEBUGF(2, "lw_dist2d_pt_seg found r = %.15g", r);
+	double r = ((C->x - A->x) * dx + (C->y - A->y) * dy) / L2;
 
-	/*This is for finding the maxdistance.
-	the maxdistance have to be between two vertices, compared to mindistance which can be between two vertices.*/
+	/*
+	 * This is for finding the maxdistance.
+	 * The maxdistance have to be between two vertices,
+	 * compared to mindistance which can be between two vertices.
+	 */
 	if (dl->mode == DIST_MAX)
 	{
 		if (r >= 0.5)
-			return lw_dist2d_pt_pt(p, A, dl);
+			return lw_dist2d_pt_pt(C, A, dl);
 		else /* (r < 0.5) */
-			return lw_dist2d_pt_pt(p, B, dl);
+			return lw_dist2d_pt_pt(C, B, dl);
 	}
-
-	if (r < 0) /*If p projected on the line is outside point A*/
-		return lw_dist2d_pt_pt(p, A, dl);
-	if (r >= 1) /*If p projected on the line is outside point B or on point B*/
-		return lw_dist2d_pt_pt(p, B, dl);
-
-	/*If the point p is on the segment this is a more robust way to find out that*/
-	if ((((A->y - p->y) * (B->x - A->x) == (A->x - p->x) * (B->y - A->y))) && (dl->mode == DIST_MIN))
-	{
-		lw_dist2d_distpts_set(dl, 0, p, p);
-	}
-
 
 	/*
-		(2)
-				  (Ay-Cy)(Bx-Ax)-(Ax-Cx)(By-Ay)
-			s = -----------------------------
-                    L^2
+	 * If projected point P is outside point A
+	 */
+	if (r < 0)
+		return lw_dist2d_pt_pt(C, A, dl);
 
-			Then the distance from C to P = |s|*L.
-	*/
+	/*
+	 * If projected point P is is outside
+	 * point B or on point B
+	 */
+	if (r >= 1)
+		return lw_dist2d_pt_pt(C, B, dl);
 
-	double s = ((A->y - p->y) * (B->x - A->x) - (A->x - p->x) * (B->y - A->y)) /
-	           ((B->x - A->x) * (B->x - A->x) + (B->y - A->y) * (B->y - A->y));
+	/*
+	 * If point C is on the segment AB then
+	 * distance is zero and nearest point is C
+	 */
+	if ((A->y - C->y) * dx == (A->x - C->x) * dy)
+	{
+		lw_dist2d_distpts_set(dl, 0.0, C, C);
+	}
 
-	double dist = fabs(s) * sqrt(((B->x - A->x) * (B->x - A->x) + (B->y - A->y) * (B->y - A->y)));
-	if ( dist < dl->distance )
+	/*
+	 *  The point P can then be found:
+	 *
+	 *      Px = Ax + r(Bx-Ax)
+	 *      Py = Ay + r(By-Ay)
+	 *
+	 *  And the distance from A to P = r*L.
+	 */
+
+	/*
+	 * If the projection of point C on the segment is
+	 * between A and B then we find that "point on segment"
+	 * and send it to lw_dist2d_pt_pt
+	 */
+	if (is_horizontal || is_vertical)
+	{
+		P.x = A->x + r * dx;
+		P.y = A->y + r * dy;
+		return lw_dist2d_pt_pt(C, &P, dl);
+	}
+
+	/*
+	 *
+	 *  Use another parameter s to indicate the location along PC, with the
+	 *  following meaning:
+	 *         s<0      C is left of AB
+	 *         s>0      C is right of AB
+	 *         s=0      C is on AB
+	 *
+	 *  Compute s as follows:
+	 *
+	 *          (Ay-Cy)(Bx-Ax)-(Ax-Cx)(By-Ay)
+	 *      s = -----------------------------
+	 *                      L^2
+	 *
+	 *
+	 *  Then the distance from C to P = s*L.
+	 */
+
+	/*
+	 * Calculate distance without reference to the
+	 * projected point P.
+	 */
+	double s = ((A->y - C->y) * dx - (A->x - C->x) * dy) / L2;
+
+	double dist = fabs(s) * sqrt(L2);
+	// double dist = fabs(s) * hypot(dx, dy);
+	if (dist < dl->distance)
 	{
 		dl->distance = dist;
 		{
-			POINT2D c;
-			c.x = A->x + r * (B->x - A->x);
-			c.y = A->y + r * (B->y - A->y);
+			P.x = A->x + r * dx;
+			P.y = A->y + r * dy;
 			if (dl->twisted > 0)
 			{
-				dl->p1 = *p;
-				dl->p2 = c;
+				dl->p1 = *C;
+				dl->p2 = P;
 			}
 			else
 			{
-				dl->p1 = c;
-				dl->p2 = *p;
+				dl->p1 = P;
+				dl->p2 = *C;
 			}
 		}
 	}
-
 	return LW_TRUE;
 }
+
 
 /** Compares incoming points and stores the points closest to each other or most far away from each other depending on
  * dl->mode (max or min) */

--- a/postgis/liblwgeom/measures.c
+++ b/postgis/liblwgeom/measures.c
@@ -301,6 +301,16 @@ lw_dist2d_gbox_reach(const GBOX *b)
 		FP_MAX(fabs(b->ymin), fabs(b->ymax)));
 }
 
+/* MEOS: the box of a segment */
+static inline void
+lw_dist2d_seg_gbox(const POINT2D *a, const POINT2D *b, GBOX *box)
+{
+	box->xmin = FP_MIN(a->x, b->x);
+	box->xmax = FP_MAX(a->x, b->x);
+	box->ymin = FP_MIN(a->y, b->y);
+	box->ymax = FP_MAX(a->y, b->y);
+}
+
 /* MEOS: whether two boxes lie further apart than a distance already found,
  * reach bounding the magnitude of their coordinates. Every distance the walk
  * computes between what the boxes hold is at least the distance between the
@@ -1297,14 +1307,44 @@ lw_dist2d_ptarray_ptarray(POINTARRAY *l1, POINTARRAY *l2, DISTPTS *dl)
 	}
 	else
 	{
+		/* MEOS: a segment further from the other line, or from a segment of
+		 * it, than the distance found holds no nearer point, as for the parts
+		 * in lw_dist2d_recursive, and the segments are still visited in order.
+		 * Nothing is skipped once the distance is within the tolerance, where
+		 * the walk ends after the next pair it measures, and the last pair is
+		 * always measured, since the orientation it leaves in dl->twisted is
+		 * the one the next call on the same distance starts from */
+		GBOX box1, box2, seg1, seg2;
+		int boxed = ptarray_calculate_gbox_cartesian(l1, &box1) == LW_SUCCESS &&
+			ptarray_calculate_gbox_cartesian(l2, &box2) == LW_SUCCESS;
+		double reach = boxed ?
+			FP_MAX(lw_dist2d_gbox_reach(&box1), lw_dist2d_gbox_reach(&box2)) : 0.0;
 		start = getPoint2d_cp(l1, 0);
 		for (t = 1; t < l1->npoints; t++) /*for each segment in L1 */
 		{
+			int last1 = (t == l1->npoints - 1);
 			end = getPoint2d_cp(l1, t);
+			lw_dist2d_seg_gbox(start, end, &seg1);
+			if (boxed && ! last1 && dl->distance > dl->tolerance &&
+			    lw_dist2d_gbox_apart(&seg1, &box2, dl->distance, reach))
+			{
+				start = end;
+				continue;
+			}
 			start2 = getPoint2d_cp(l2, 0);
 			for (u = 1; u < l2->npoints; u++) /*for each segment in L2 */
 			{
 				end2 = getPoint2d_cp(l2, u);
+				if (boxed && ! (last1 && u == l2->npoints - 1) &&
+				    dl->distance > dl->tolerance)
+				{
+					lw_dist2d_seg_gbox(start2, end2, &seg2);
+					if (lw_dist2d_gbox_apart(&seg1, &seg2, dl->distance, reach))
+					{
+						start2 = end2;
+						continue;
+					}
+				}
 				dl->twisted = twist;
 				lw_dist2d_seg_seg(start, end, start2, end2, dl);
 				if (dl->distance <= dl->tolerance && dl->mode == DIST_MIN)

--- a/postgis/liblwgeom/measures.c
+++ b/postgis/liblwgeom/measures.c
@@ -390,6 +390,38 @@ lw_dist2d_recursive(const LWGEOM *lwg1, const LWGEOM *lwg2, DISTPTS *dl)
 	return LW_TRUE;
 }
 
+/* MEOS: the walk above records the two ends of the shortest line in the order
+ * of its own two arguments, which is what dl->twisted states for each pair it
+ * measures. A curve polygon measures one of its rings against the other
+ * geometry by that walk, in the order the two reach the curve polygon's own
+ * function, which is the order of the pair being measured only where
+ * dl->twisted is positive. Where it is negative, the ends are read in the
+ * other order on the way in and on the way out, and dl->twisted is restored
+ * for the caller */
+static int
+lw_dist2d_recursive_oriented(const LWGEOM *lwg1, const LWGEOM *lwg2, DISTPTS *dl)
+{
+	int twisted = dl->twisted;
+	POINT2D p;
+	int rv;
+
+	if (twisted < 0)
+	{
+		p = dl->p1;
+		dl->p1 = dl->p2;
+		dl->p2 = p;
+	}
+	rv = lw_dist2d_recursive(lwg1, lwg2, dl);
+	if (twisted < 0)
+	{
+		p = dl->p1;
+		dl->p1 = dl->p2;
+		dl->p2 = p;
+	}
+	dl->twisted = twisted;
+	return rv;
+}
+
 int
 lw_dist2d_distribute_bruteforce(const LWGEOM *lwg1, const LWGEOM *lwg2, DISTPTS *dl)
 {
@@ -694,7 +726,7 @@ lw_dist2d_point_curvepoly(LWPOINT *point, LWCURVEPOLY *poly, DISTPTS *dl)
 
 	/* Return distance to outer ring if not inside it */
 	if (lwgeom_contains_point(poly->rings[0], p) == LW_OUTSIDE)
-		return lw_dist2d_recursive((LWGEOM *)point, poly->rings[0], dl);
+		return lw_dist2d_recursive_oriented((LWGEOM *)point, poly->rings[0], dl);
 
 	/* Inside the outer ring.
 	 * Scan though each of the inner rings looking to see if its inside.  If not, distance==0.
@@ -702,7 +734,7 @@ lw_dist2d_point_curvepoly(LWPOINT *point, LWCURVEPOLY *poly, DISTPTS *dl)
 	 */
 	for (uint32_t i = 1; i < poly->nrings; i++)
 		if (lwgeom_contains_point(poly->rings[i], p) == LW_INSIDE)
-			return lw_dist2d_recursive((LWGEOM *)point, poly->rings[i], dl);
+			return lw_dist2d_recursive_oriented((LWGEOM *)point, poly->rings[i], dl);
 
 	/* Is inside the polygon */
 	lw_dist2d_distpts_set(dl, 0.0, p, p);
@@ -788,11 +820,11 @@ lw_dist2d_line_curvepoly(LWLINE *line, LWCURVEPOLY *poly, DISTPTS *dl)
 
 	/* Line has a point outside curvepoly. Check distance to outer ring only. */
 	if (lwgeom_contains_point(poly->rings[0], pt) == LW_OUTSIDE)
-		return lw_dist2d_recursive((LWGEOM *)line, poly->rings[0], dl);
+		return lw_dist2d_recursive_oriented((LWGEOM *)line, poly->rings[0], dl);
 
 	for (uint32_t i = 1; i < poly->nrings; i++)
 	{
-		if (!lw_dist2d_recursive((LWGEOM *)line, poly->rings[i], dl))
+		if (!lw_dist2d_recursive_oriented((LWGEOM *)line, poly->rings[i], dl))
 			return LW_FALSE;
 
 		/* just a check if the answer is already given */
@@ -911,12 +943,12 @@ lw_dist2d_tri_curvepoly(LWTRIANGLE *tri, LWCURVEPOLY *poly, DISTPTS *dl)
 
 	/* If we are looking for maxdistance, just check the outer rings.*/
 	if (dl->mode == DIST_MAX)
-		return lw_dist2d_recursive((LWGEOM *)tri, poly->rings[0], dl);
+		return lw_dist2d_recursive_oriented((LWGEOM *)tri, poly->rings[0], dl);
 
 	/* Line has a point outside curvepoly. Check distance to outer ring only. */
 	if (lwgeom_contains_point(poly->rings[0], pt) == LW_OUTSIDE)
 	{
-		if (lw_dist2d_recursive((LWGEOM *)tri, poly->rings[0], dl))
+		if (lw_dist2d_recursive_oriented((LWGEOM *)tri, poly->rings[0], dl))
 			return LW_TRUE;
 		/* Maybe poly is inside triangle? */
 		if (lwgeom_contains_point((LWGEOM *)tri, lw_curvering_getfirstpoint2d_cp(poly->rings[0])) != LW_OUTSIDE)
@@ -928,7 +960,7 @@ lw_dist2d_tri_curvepoly(LWTRIANGLE *tri, LWCURVEPOLY *poly, DISTPTS *dl)
 
 	for (uint32_t i = 1; i < poly->nrings; i++)
 	{
-		if (!lw_dist2d_recursive((LWGEOM *)tri, poly->rings[i], dl))
+		if (!lw_dist2d_recursive_oriented((LWGEOM *)tri, poly->rings[i], dl))
 			return LW_FALSE;
 
 		/* just a check if the answer is already given */
@@ -1061,7 +1093,7 @@ lw_dist2d_curvepoly_curvepoly(LWCURVEPOLY *poly1, LWCURVEPOLY *poly2, DISTPTS *d
 
 	/*1	if we are looking for maxdistance, just check the outer rings.*/
 	if (dl->mode == DIST_MAX)
-		return lw_dist2d_recursive(poly1->rings[0], poly2->rings[0], dl);
+		return lw_dist2d_recursive_oriented(poly1->rings[0], poly2->rings[0], dl);
 
 	/* 2	check if poly1 has first point outside poly2 and vice versa, if so, just check outer rings
 	here it would be possible to handle the information about which one is inside which one and only search for the
@@ -1071,7 +1103,7 @@ lw_dist2d_curvepoly_curvepoly(LWCURVEPOLY *poly1, LWCURVEPOLY *poly2, DISTPTS *d
 	{
 		pt = lw_curvering_getfirstpoint2d_cp(poly2->rings[0]);
 		if (lwgeom_contains_point(poly1->rings[0], pt) == LW_OUTSIDE)
-			return lw_dist2d_recursive(poly1->rings[0], poly2->rings[0], dl);
+			return lw_dist2d_recursive_oriented(poly1->rings[0], poly2->rings[0], dl);
 	}
 
 	/*3	check if first point of poly2 is in a hole of poly1. If so check outer ring of poly2 against that hole
@@ -1079,14 +1111,14 @@ lw_dist2d_curvepoly_curvepoly(LWCURVEPOLY *poly1, LWCURVEPOLY *poly2, DISTPTS *d
 	pt = lw_curvering_getfirstpoint2d_cp(poly2->rings[0]);
 	for (uint32_t i = 1; i < poly1->nrings; i++)
 		if (lwgeom_contains_point(poly1->rings[i], pt) != LW_OUTSIDE)
-			return lw_dist2d_recursive(poly1->rings[i], poly2->rings[0], dl);
+			return lw_dist2d_recursive_oriented(poly1->rings[i], poly2->rings[0], dl);
 
 	/*4	check if first point of poly1 is in a hole of poly2. If so check outer ring of poly1 against that hole
 	 * of poly2*/
 	pt = lw_curvering_getfirstpoint2d_cp(poly1->rings[0]);
 	for (uint32_t i = 1; i < poly2->nrings; i++)
 		if (lwgeom_contains_point(poly2->rings[i], pt) != LW_OUTSIDE)
-			return lw_dist2d_recursive(poly1->rings[0], poly2->rings[i], dl);
+			return lw_dist2d_recursive_oriented(poly1->rings[0], poly2->rings[i], dl);
 
 	/*5	If we have come all the way here we know that the first point of one of them is inside the other ones
 	 * outer ring and not in holes so we check which one is inside.*/
@@ -1497,8 +1529,13 @@ lw_dist2d_seg_arc(const POINT2D *A1,
 	/* or, one of the arc end points is the closest */
 	else if (pt_in_seg && !pt_in_arc)
 	{
+		/* MEOS: an end of the arc measured against the segment reads the two
+		 * geometries in the other order, which dl->twisted records, as in
+		 * lw_dist2d_seg_seg */
+		dl->twisted = -dl->twisted;
 		lw_dist2d_pt_seg(B1, A1, A2, dl);
 		lw_dist2d_pt_seg(B3, A1, A2, dl);
+		dl->twisted = -dl->twisted;
 		return LW_TRUE;
 	}
 	/* Finally, one of the end-point to end-point combos is the closest. */
@@ -1583,7 +1620,7 @@ lw_dist2d_pt_arc(const POINT2D *P, const POINT2D *A1, const POINT2D *A2, const P
 		POINT2D X;
 		if (d == 0.0)
 		{
-			lw_dist2d_pt_pt_at(A1, P, r, dl);
+			lw_dist2d_pt_pt_at(P, A1, r, dl); /* MEOS: P, of the first geometry, first */
 			return LW_TRUE;
 		}
 		X.x = P->x - (d - r) * dx / d;
@@ -1614,7 +1651,7 @@ lw_dist2d_pt_arc(const POINT2D *P, const POINT2D *A1, const POINT2D *A2, const P
 	/* P is the centre of the circle, every point of the arc at the radius */
 	if (pc == 0.0)
 	{
-		lw_dist2d_pt_pt_at(A1, P, radius, dl);
+		lw_dist2d_pt_pt_at(P, A1, radius, dl); /* MEOS: P, of the first geometry, first */
 		return LW_TRUE;
 	}
 
@@ -1633,9 +1670,10 @@ lw_dist2d_pt_arc(const POINT2D *P, const POINT2D *A1, const POINT2D *A2, const P
 	}
 	else
 	{
-		/* Distance is the minimum of the distances to the arc end points */
-		lw_dist2d_pt_pt(A1, P, dl);
-		lw_dist2d_pt_pt(A3, P, dl);
+		/* Distance is the minimum of the distances to the arc end points;
+		 * MEOS: each measured from P, the point of the first geometry */
+		lw_dist2d_pt_pt(P, A1, dl);
+		lw_dist2d_pt_pt(P, A3, dl);
 	}
 	return LW_TRUE;
 }
@@ -1795,9 +1833,18 @@ lw_dist2d_arc_arc(
 
 	/* What if one or both of our "arcs" is actually a point? */
 	if (lw_arc_is_pt(B1, B2, B3) && lw_arc_is_pt(A1, A2, A3))
-		return lw_dist2d_pt_pt(B1, A1, dl);
+		return lw_dist2d_pt_pt(A1, B1, dl); /* MEOS: the point of A first */
 	else if (lw_arc_is_pt(B1, B2, B3))
-		return lw_dist2d_pt_arc(B1, A1, A2, A3, dl);
+	{
+		/* MEOS: the point B1 measured against the arc A reads the two
+		 * geometries in the other order, which dl->twisted records, as in
+		 * lw_dist2d_seg_seg */
+		int rv;
+		dl->twisted = -dl->twisted;
+		rv = lw_dist2d_pt_arc(B1, A1, A2, A3, dl);
+		dl->twisted = -dl->twisted;
+		return rv;
+	}
 	else if (lw_arc_is_pt(A1, A2, A3))
 		return lw_dist2d_pt_arc(A1, B1, B2, B3, dl);
 
@@ -1815,7 +1862,15 @@ lw_dist2d_arc_arc(
 
 	/* B is co-linear, delegate to lw_dist_seg_arc here. */
 	if (radius_B < 0)
-		return lw_dist2d_seg_arc(B1, B3, A1, A2, A3, dl);
+	{
+		/* MEOS: the segment B1-B3 measured against the arc A reads the two
+		 * geometries in the other order, which dl->twisted records */
+		int rv;
+		dl->twisted = -dl->twisted;
+		rv = lw_dist2d_seg_arc(B1, B3, A1, A2, A3, dl);
+		dl->twisted = -dl->twisted;
+		return rv;
+	}
 
 	/* Circle relationships */
 	d = distance2d_pt_pt(&center_A, &center_B);

--- a/postgis/liblwgeom/measures.c
+++ b/postgis/liblwgeom/measures.c
@@ -277,6 +277,22 @@ lw_dist2d_is_collection(const LWGEOM *g)
 	}
 }
 
+
+/* Check for overlapping bboxes */
+static int
+lw_dist2d_check_overlap(const LWGEOM *lwg1, const LWGEOM *lwg2)
+{
+	assert(lwg1 && lwg2 && lwg1->bbox && lwg2->bbox);
+
+	/* Check if the geometries intersect. */
+	if ((lwg1->bbox->xmax < lwg2->bbox->xmin || lwg1->bbox->xmin > lwg2->bbox->xmax ||
+	     lwg1->bbox->ymax < lwg2->bbox->ymin || lwg1->bbox->ymin > lwg2->bbox->ymax))
+	{
+		return LW_FALSE;
+	}
+	return LW_TRUE;
+}
+
 /**
 This is a recursive function delivering every possible combination of subgeometries
 */
@@ -314,6 +330,8 @@ lw_dist2d_recursive(const LWGEOM *lwg1, const LWGEOM *lwg2, DISTPTS *dl)
 		else
 			g1 = (LWGEOM *)lwg1;
 
+		if (!g1) continue;
+
 		if (lwgeom_is_empty(g1))
 			continue;
 
@@ -330,6 +348,8 @@ lw_dist2d_recursive(const LWGEOM *lwg1, const LWGEOM *lwg2, DISTPTS *dl)
 				g2 = c2->geoms[j];
 			else
 				g2 = (LWGEOM *)lwg2;
+
+			if (!g2) continue;
 
 			if (lw_dist2d_is_collection(g2))
 			{
@@ -530,26 +550,6 @@ lw_dist2d_distribute_bruteforce(const LWGEOM *lwg1, const LWGEOM *lwg2, DISTPTS 
 	return LW_FALSE;
 }
 
-/* Check for overlapping bboxes */
-int
-lw_dist2d_check_overlap(LWGEOM *lwg1, LWGEOM *lwg2)
-{
-	LWDEBUG(2, "lw_dist2d_check_overlap is called");
-	if (!lwg1->bbox)
-		lwgeom_calculate_gbox(lwg1, lwg1->bbox);
-	if (!lwg2->bbox)
-		lwgeom_calculate_gbox(lwg2, lwg2->bbox);
-
-	/* Check if the geometries intersect. */
-	if ((lwg1->bbox->xmax < lwg2->bbox->xmin || lwg1->bbox->xmin > lwg2->bbox->xmax ||
-	     lwg1->bbox->ymax < lwg2->bbox->ymin || lwg1->bbox->ymin > lwg2->bbox->ymax))
-	{
-		LWDEBUG(3, "geometries bboxes did not overlap");
-		return LW_FALSE;
-	}
-	LWDEBUG(3, "geometries bboxes overlap");
-	return LW_TRUE;
-}
 
 /** Geometries are distributed for the new faster distance-calculations */
 int

--- a/postgis/liblwgeom/measures.c
+++ b/postgis/liblwgeom/measures.c
@@ -1399,17 +1399,33 @@ lw_dist2d_seg_arc(const POINT2D *A1,
 	{
 		double length_A;  /* length of the segment A */
 		POINT2D E, F;     /* points of intersection of edge A and circle(B) */
-		double dist_D_EF; /* distance from D to E or F (same distance both ways) */
+		double dist_D_EF; /* distance from D_line to E or F (same distance both ways) */
+		POINT2D D_line;   /* foot of perpendicular from C to the infinite line through A1-A2 */
+		double dist_C_D_line; /* distance from C to the infinite line */
+		double t;
 
-		dist_D_EF = sqrt(radius_C * radius_C - dist_C_D * dist_C_D);
 		length_A = sqrt((A2->x - A1->x) * (A2->x - A1->x) + (A2->y - A1->y) * (A2->y - A1->y));
 
+		/*
+		 * D (from lw_dist2d_pt_seg) is clamped to the segment, but we need the
+		 * foot of the perpendicular on the *infinite* line to correctly compute
+		 * circle-line intersections E and F. Using the clamped endpoint gives wrong
+		 * intersection points when the perpendicular falls outside the segment.
+		 */
+		t = ((C.x - A1->x) * (A2->x - A1->x) + (C.y - A1->y) * (A2->y - A1->y))
+		    / (length_A * length_A);
+		D_line.x = A1->x + t * (A2->x - A1->x);
+		D_line.y = A1->y + t * (A2->y - A1->y);
+		dist_C_D_line = sqrt((C.x - D_line.x) * (C.x - D_line.x) + (C.y - D_line.y) * (C.y - D_line.y));
+
+		dist_D_EF = sqrt(radius_C * radius_C - dist_C_D_line * dist_C_D_line);
+
 		/* Point of intersection E */
-		E.x = D.x - (A2->x - A1->x) * dist_D_EF / length_A;
-		E.y = D.y - (A2->y - A1->y) * dist_D_EF / length_A;
+		E.x = D_line.x - (A2->x - A1->x) * dist_D_EF / length_A;
+		E.y = D_line.y - (A2->y - A1->y) * dist_D_EF / length_A;
 		/* Point of intersection F */
-		F.x = D.x + (A2->x - A1->x) * dist_D_EF / length_A;
-		F.y = D.y + (A2->y - A1->y) * dist_D_EF / length_A;
+		F.x = D_line.x + (A2->x - A1->x) * dist_D_EF / length_A;
+		F.y = D_line.y + (A2->y - A1->y) * dist_D_EF / length_A;
 
 		/* If E is within A and within B then it's an intersection point */
 		pt_in_arc = lw_pt_in_arc(&E, B1, B2, B3);

--- a/postgis/liblwgeom/measures.c
+++ b/postgis/liblwgeom/measures.c
@@ -1386,27 +1386,76 @@ lw_dist2d_ptarray_ptarrayarc(const POINTARRAY *pa, const POINTARRAY *pb, DISTPTS
 	}
 	else
 	{
+		/* MEOS: a segment further from the arcs, or from one arc of them, than
+		 * the distance found holds no nearer point, as for the segments in
+		 * lw_dist2d_ptarray_ptarray, the box of an arc enclosing the arc it
+		 * draws. The pairs are still visited in order, nothing is skipped once
+		 * the distance is within the tolerance, and the last pair is always
+		 * measured. The box of each arc is built once, for every segment it is
+		 * measured against */
+		uint32_t narcs = (pb->npoints - 1) / 2, k;
+		GBOX box1, box2, seg1;
+		GBOX *arcbox = lwalloc(sizeof(GBOX) * narcs);
+		int boxed = ptarray_calculate_gbox_cartesian(pa, &box1) == LW_SUCCESS;
+		double reach = 0.0;
+		B1 = getPoint2d_cp(pb, 0);
+		for (k = 0; k < narcs; k++)
+		{
+			B2 = getPoint2d_cp(pb, 2 * k + 1);
+			B3 = getPoint2d_cp(pb, 2 * k + 2);
+			lw_arc_calculate_gbox_cartesian_2d(B1, B2, B3, &arcbox[k]);
+			B1 = B3;
+		}
+		box2 = arcbox[0];
+		for (k = 1; k < narcs; k++)
+		{
+			box2.xmin = FP_MIN(box2.xmin, arcbox[k].xmin);
+			box2.xmax = FP_MAX(box2.xmax, arcbox[k].xmax);
+			box2.ymin = FP_MIN(box2.ymin, arcbox[k].ymin);
+			box2.ymax = FP_MAX(box2.ymax, arcbox[k].ymax);
+		}
+		if (boxed)
+			reach = FP_MAX(lw_dist2d_gbox_reach(&box1), lw_dist2d_gbox_reach(&box2));
 		A1 = getPoint2d_cp(pa, 0);
 		for (t = 1; t < pa->npoints; t++) /* For each segment in pa */
 		{
+			int last1 = (t == pa->npoints - 1);
 			A2 = getPoint2d_cp(pa, t);
+			lw_dist2d_seg_gbox(A1, A2, &seg1);
+			if (boxed && ! last1 && dl->distance > dl->tolerance &&
+			    lw_dist2d_gbox_apart(&seg1, &box2, dl->distance, reach))
+			{
+				A1 = A2;
+				continue;
+			}
 			B1 = getPoint2d_cp(pb, 0);
-			for (u = 1; u < pb->npoints; u += 2) /* For each arc in pb */
+			for (u = 1, k = 0; u < pb->npoints; u += 2, k++) /* For each arc in pb */
 			{
 				B2 = getPoint2d_cp(pb, u);
 				B3 = getPoint2d_cp(pb, u + 1);
+				if (boxed && ! (last1 && u == pb->npoints - 2) &&
+				    dl->distance > dl->tolerance &&
+				    lw_dist2d_gbox_apart(&seg1, &arcbox[k], dl->distance, reach))
+				{
+					B1 = B3;
+					continue;
+				}
 				dl->twisted = twist;
 
 				lw_dist2d_seg_arc(A1, A2, B1, B2, B3, dl);
 
 				/* If we've found a distance within tolerance, we're done */
 				if (dl->distance <= dl->tolerance && dl->mode == DIST_MIN)
+				{
+					lwfree(arcbox);
 					return LW_TRUE;
+				}
 
 				B1 = B3;
 			}
 			A1 = A2;
 		}
+		lwfree(arcbox);
 	}
 	return LW_TRUE;
 }

--- a/postgis/liblwgeom/measures.c
+++ b/postgis/liblwgeom/measures.c
@@ -77,6 +77,18 @@ lw_dist2d_distpts_init(DISTPTS *dl, int mode)
 		dl->distance = -1 * FLT_MAX;
 }
 
+static void
+lw_dist2d_distpts_set(DISTPTS *dl, double distance, const POINT2D *p1, const POINT2D *p2)
+{
+	int update = (dl->mode == DIST_MIN) ? (distance < dl->distance) : (distance > dl->distance);
+	if (update)
+	{
+		dl->distance = distance;
+		dl->p1 = *p1;
+		dl->p2 = *p2;
+	}
+}
+
 /**
 Function initializing shortestline and longestline calculations.
 */
@@ -621,9 +633,7 @@ lw_dist2d_point_tri(LWPOINT *point, LWTRIANGLE *tri, DISTPTS *dl)
 	/* Is point inside triangle? */
 	if (dl->mode == DIST_MIN && ptarray_contains_point(tri->points, pt) != LW_OUTSIDE)
 	{
-		dl->distance = 0.0;
-		dl->p1.x = dl->p2.x = pt->x;
-		dl->p1.y = dl->p2.y = pt->y;
+		lw_dist2d_distpts_set(dl, 0.0, pt, pt);
 		return LW_TRUE;
 	}
 
@@ -667,9 +677,7 @@ lw_dist2d_point_poly(LWPOINT *point, LWPOLY *poly, DISTPTS *dl)
 			return lw_dist2d_pt_ptarray(p, poly->rings[i], dl);
 
 	/* Is inside the polygon */
-	dl->distance = 0.0;
-	dl->p1.x = dl->p2.x = p->x;
-	dl->p1.y = dl->p2.y = p->y;
+	lw_dist2d_distpts_set(dl, 0.0, p, p);
 	return LW_TRUE;
 }
 
@@ -697,9 +705,7 @@ lw_dist2d_point_curvepoly(LWPOINT *point, LWCURVEPOLY *poly, DISTPTS *dl)
 			return lw_dist2d_recursive((LWGEOM *)point, poly->rings[i], dl);
 
 	/* Is inside the polygon */
-	dl->distance = 0.0;
-	dl->p1.x = dl->p2.x = p->x;
-	dl->p1.y = dl->p2.y = p->y;
+	lw_dist2d_distpts_set(dl, 0.0, p, p);
 	return LW_TRUE;
 }
 
@@ -718,9 +724,7 @@ lw_dist2d_line_tri(LWLINE *line, LWTRIANGLE *tri, DISTPTS *dl)
 	/* Is there a point inside triangle? */
 	if (dl->mode == DIST_MIN && ptarray_contains_point(tri->points, pt) != LW_OUTSIDE)
 	{
-		dl->distance = 0.0;
-		dl->p1.x = dl->p2.x = pt->x;
-		dl->p1.y = dl->p2.y = pt->y;
+		lw_dist2d_distpts_set(dl, 0.0, pt, pt);
 		return LW_TRUE;
 	}
 
@@ -772,9 +776,7 @@ lw_dist2d_line_poly(LWLINE *line, LWPOLY *poly, DISTPTS *dl)
 	/* Not in hole, so inside polygon */
 	if (dl->mode == DIST_MIN)
 	{
-		dl->distance = 0.0;
-		dl->p1.x = dl->p2.x = pt->x;
-		dl->p1.y = dl->p2.y = pt->y;
+		lw_dist2d_distpts_set(dl, 0.0, pt, pt);
 	}
 	return LW_TRUE;
 }
@@ -806,9 +808,7 @@ lw_dist2d_line_curvepoly(LWLINE *line, LWCURVEPOLY *poly, DISTPTS *dl)
 	/* Not in hole, so inside polygon */
 	if (dl->mode == DIST_MIN)
 	{
-		dl->distance = 0.0;
-		dl->p1.x = dl->p2.x = pt->x;
-		dl->p1.y = dl->p2.y = pt->y;
+		lw_dist2d_distpts_set(dl, 0.0, pt, pt);
 	}
 	return LW_TRUE;
 }
@@ -821,18 +821,14 @@ lw_dist2d_tri_tri(LWTRIANGLE *tri1, LWTRIANGLE *tri2, DISTPTS *dl)
 	const POINT2D *pt = getPoint2d_cp(pa2, 0);
 	if (dl->mode == DIST_MIN && ptarray_contains_point(pa1, pt) != LW_OUTSIDE)
 	{
-		dl->distance = 0.0;
-		dl->p1.x = dl->p2.x = pt->x;
-		dl->p1.y = dl->p2.y = pt->y;
+		lw_dist2d_distpts_set(dl, 0.0, pt, pt);
 		return LW_TRUE;
 	}
 
 	pt = getPoint2d_cp(pa1, 0);
 	if (dl->mode == DIST_MIN && ptarray_contains_point(pa2, pt) != LW_OUTSIDE)
 	{
-		dl->distance = 0.0;
-		dl->p1.x = dl->p2.x = pt->x;
-		dl->p1.y = dl->p2.y = pt->y;
+		lw_dist2d_distpts_set(dl, 0.0, pt, pt);
 		return LW_TRUE;
 	}
 
@@ -863,9 +859,7 @@ lw_dist2d_tri_poly(LWTRIANGLE *tri, LWPOLY *poly, DISTPTS *dl)
 		const POINT2D *pt2 = getPoint2d_cp(poly->rings[0], 0);
 		if (ptarray_contains_point(pa, pt2) != LW_OUTSIDE)
 		{
-			dl->distance = 0.0;
-			dl->p1.x = dl->p2.x = pt2->x;
-			dl->p1.y = dl->p2.y = pt2->y;
+			lw_dist2d_distpts_set(dl, 0.0, pt2, pt2);
 			return LW_TRUE;
 		}
 	}
@@ -886,9 +880,7 @@ lw_dist2d_tri_poly(LWTRIANGLE *tri, LWPOLY *poly, DISTPTS *dl)
 			return LW_TRUE;
 
 	/* Not in hole, so inside polygon */
-	dl->distance = 0.0;
-	dl->p1.x = dl->p2.x = pt->x;
-	dl->p1.y = dl->p2.y = pt->y;
+	lw_dist2d_distpts_set(dl, 0.0, pt, pt);
 	return LW_TRUE;
 }
 static const POINT2D *
@@ -929,9 +921,7 @@ lw_dist2d_tri_curvepoly(LWTRIANGLE *tri, LWCURVEPOLY *poly, DISTPTS *dl)
 		/* Maybe poly is inside triangle? */
 		if (lwgeom_contains_point((LWGEOM *)tri, lw_curvering_getfirstpoint2d_cp(poly->rings[0])) != LW_OUTSIDE)
 		{
-			dl->distance = 0.0;
-			dl->p1.x = dl->p2.x = pt->x;
-			dl->p1.y = dl->p2.y = pt->y;
+			lw_dist2d_distpts_set(dl, 0.0, pt, pt);
 			return LW_TRUE;
 		}
 	}
@@ -952,9 +942,7 @@ lw_dist2d_tri_curvepoly(LWTRIANGLE *tri, LWCURVEPOLY *poly, DISTPTS *dl)
 			return LW_TRUE;
 
 	/* Not in hole, so inside polygon */
-	dl->distance = 0.0;
-	dl->p1.x = dl->p2.x = pt->x;
-	dl->p1.y = dl->p2.y = pt->y;
+	lw_dist2d_distpts_set(dl, 0.0, pt, pt);
 	return LW_TRUE;
 }
 
@@ -964,9 +952,7 @@ lw_dist2d_tri_circstring(LWTRIANGLE *tri, LWCIRCSTRING *line, DISTPTS *dl)
 	const POINT2D *pt = lw_curvering_getfirstpoint2d_cp((LWGEOM *)line);
 	if (ptarray_contains_point(tri->points, pt) != LW_OUTSIDE && dl->mode == DIST_MIN)
 	{
-		dl->distance = 0.0;
-		dl->p1.x = dl->p2.x = pt->x;
-		dl->p1.y = dl->p2.y = pt->y;
+		lw_dist2d_distpts_set(dl, 0.0, pt, pt);
 		return LW_TRUE;
 	}
 
@@ -1023,18 +1009,14 @@ lw_dist2d_poly_poly(LWPOLY *poly1, LWPOLY *poly2, DISTPTS *dl)
 	pt = getPoint2d_cp(poly1->rings[0], 0);
 	if (ptarray_contains_point(poly2->rings[0], pt) != LW_OUTSIDE)
 	{
-		dl->distance = 0.0;
-		dl->p1.x = dl->p2.x = pt->x;
-		dl->p1.y = dl->p2.y = pt->y;
+		lw_dist2d_distpts_set(dl, 0.0, pt, pt);
 		return LW_TRUE;
 	}
 
 	pt = getPoint2d_cp(poly2->rings[0], 0);
 	if (ptarray_contains_point(poly1->rings[0], pt) != LW_OUTSIDE)
 	{
-		dl->distance = 0.0;
-		dl->p1.x = dl->p2.x = pt->x;
-		dl->p1.y = dl->p2.y = pt->y;
+		lw_dist2d_distpts_set(dl, 0.0, pt, pt);
 		return LW_TRUE;
 	}
 
@@ -1111,18 +1093,14 @@ lw_dist2d_curvepoly_curvepoly(LWCURVEPOLY *poly1, LWCURVEPOLY *poly2, DISTPTS *d
 	pt = lw_curvering_getfirstpoint2d_cp(poly1->rings[0]);
 	if (lwgeom_contains_point(poly2->rings[0], pt) != LW_OUTSIDE)
 	{
-		dl->distance = 0.0;
-		dl->p1.x = dl->p2.x = pt->x;
-		dl->p1.y = dl->p2.y = pt->y;
+		lw_dist2d_distpts_set(dl, 0.0, pt, pt);
 		return LW_TRUE;
 	}
 
 	pt = lw_curvering_getfirstpoint2d_cp(poly2->rings[0]);
 	if (lwgeom_contains_point(poly1->rings[0], pt) != LW_OUTSIDE)
 	{
-		dl->distance = 0.0;
-		dl->p1.x = dl->p2.x = pt->x;
-		dl->p1.y = dl->p2.y = pt->y;
+		lw_dist2d_distpts_set(dl, 0.0, pt, pt);
 		return LW_TRUE;
 	}
 
@@ -1439,9 +1417,7 @@ lw_dist2d_seg_arc(const POINT2D *A1,
 
 		if (pt_in_arc && pt_in_seg)
 		{
-			dl->distance = 0.0;
-			dl->p1 = E;
-			dl->p2 = E;
+			lw_dist2d_distpts_set(dl, 0.0, &E, &E);
 			return LW_TRUE;
 		}
 
@@ -1451,9 +1427,7 @@ lw_dist2d_seg_arc(const POINT2D *A1,
 
 		if (pt_in_arc && pt_in_seg)
 		{
-			dl->distance = 0.0;
-			dl->p1 = F;
-			dl->p2 = F;
+			lw_dist2d_distpts_set(dl, 0.0, &F, &F);
 			return LW_TRUE;
 		}
 	}
@@ -1470,9 +1444,7 @@ lw_dist2d_seg_arc(const POINT2D *A1,
 		/* Is D contained in both A and B? */
 		if (pt_in_arc && pt_in_seg)
 		{
-			dl->distance = 0.0;
-			dl->p1 = D;
-			dl->p2 = D;
+			lw_dist2d_distpts_set(dl, 0.0, &D, &D);
 			return LW_TRUE;
 		}
 	}
@@ -1752,9 +1724,7 @@ lw_dist2d_arc_arc(const POINT2D *A1,
 		/* Arcs do touch at D, return it */
 		if (pt_in_arc_A && pt_in_arc_B)
 		{
-			dl->distance = 0.0;
-			dl->p1 = D;
-			dl->p2 = D;
+			lw_dist2d_distpts_set(dl, 0.0, &D, &D);
 			return LW_TRUE;
 		}
 	}
@@ -1806,8 +1776,7 @@ lw_dist2d_arc_arc(const POINT2D *A1,
 
 		if (pt_in_arc_A && pt_in_arc_B)
 		{
-			dl->p1 = dl->p2 = E;
-			dl->distance = 0.0;
+			lw_dist2d_distpts_set(dl, 0.0, &E, &E);
 			return LW_TRUE;
 		}
 
@@ -1821,8 +1790,7 @@ lw_dist2d_arc_arc(const POINT2D *A1,
 
 		if (pt_in_arc_A && pt_in_arc_B)
 		{
-			dl->p1 = dl->p2 = F;
-			dl->distance = 0.0;
+			lw_dist2d_distpts_set(dl, 0.0, &F, &F);
 			return LW_TRUE;
 		}
 	}
@@ -1885,32 +1853,24 @@ lw_dist2d_arc_arc_concentric(const POINT2D *A1,
 		seg_size = lw_segment_side(A1, A3, A2);
 		if (seg_size == lw_segment_side(A1, A3, B1))
 		{
-			dl->p1 = *B1;
-			dl->p2 = *B1;
-			dl->distance = 0;
+			lw_dist2d_distpts_set(dl, 0.0, B1, B1);
 			return LW_TRUE;
 		}
 		if (seg_size == lw_segment_side(A1, A3, B3))
 		{
-			dl->p1 = *B3;
-			dl->p2 = *B3;
-			dl->distance = 0;
+			lw_dist2d_distpts_set(dl, 0.0, B3, B3);
 			return LW_TRUE;
 		}
 		/* Check if A1 or A3 are in the same side as B2 in the B1-B3 arc */
 		seg_size = lw_segment_side(B1, B3, B2);
 		if (seg_size == lw_segment_side(B1, B3, A1))
 		{
-			dl->p1 = *A1;
-			dl->p2 = *A1;
-			dl->distance = 0;
+			lw_dist2d_distpts_set(dl, 0.0, A1, A1);
 			return LW_TRUE;
 		}
 		if (seg_size == lw_segment_side(B1, B3, A3))
 		{
-			dl->p1 = *A3;
-			dl->p2 = *A3;
-			dl->distance = 0;
+			lw_dist2d_distpts_set(dl, 0.0, A3, A3);
 			return LW_TRUE;
 		}
 	}
@@ -1925,9 +1885,7 @@ lw_dist2d_arc_arc_concentric(const POINT2D *A1,
 
 		if (seg_size == lw_segment_side(A1, A3, &proj))
 		{
-			dl->p1 = proj;
-			dl->p2 = *B1;
-			dl->distance = fabs(radius_A - radius_B);
+			lw_dist2d_distpts_set(dl, fabs(radius_A - radius_B), &proj, B1);
 			return LW_TRUE;
 		}
 		/* B3 */
@@ -1935,9 +1893,7 @@ lw_dist2d_arc_arc_concentric(const POINT2D *A1,
 		proj.y = CENTER->y + (B3->y - CENTER->y) * radius_A / radius_B;
 		if (seg_size == lw_segment_side(A1, A3, &proj))
 		{
-			dl->p1 = proj;
-			dl->p2 = *B3;
-			dl->distance = fabs(radius_A - radius_B);
+			lw_dist2d_distpts_set(dl, fabs(radius_A - radius_B), &proj, B3);
 			return LW_TRUE;
 		}
 
@@ -1949,9 +1905,7 @@ lw_dist2d_arc_arc_concentric(const POINT2D *A1,
 		proj.y = CENTER->y + (A1->y - CENTER->y) * radius_B / radius_A;
 		if (seg_size == lw_segment_side(B1, B3, &proj))
 		{
-			dl->p1 = proj;
-			dl->p2 = *A1;
-			dl->distance = fabs(radius_A - radius_B);
+			lw_dist2d_distpts_set(dl, fabs(radius_A - radius_B), &proj, A1);
 			return LW_TRUE;
 		}
 
@@ -1960,9 +1914,7 @@ lw_dist2d_arc_arc_concentric(const POINT2D *A1,
 		proj.y = CENTER->y + (A3->y - CENTER->y) * radius_B / radius_A;
 		if (seg_size == lw_segment_side(B1, B3, &proj))
 		{
-			dl->p1 = proj;
-			dl->p2 = *A3;
-			dl->distance = fabs(radius_A - radius_B);
+			lw_dist2d_distpts_set(dl, fabs(radius_A - radius_B), &proj, A3);
 			return LW_TRUE;
 		}
 	}
@@ -1996,10 +1948,7 @@ lw_dist2d_arc_arc_concentric(const POINT2D *A1,
 		P2 = B3;
 	}
 
-	dl->p1 = *P1;
-	dl->p2 = *P2;
-	dl->distance = sqrt(shortest_sqr);
-
+	lw_dist2d_distpts_set(dl, sqrt(shortest_sqr), P1, P2);
 	return LW_TRUE;
 }
 
@@ -2104,9 +2053,7 @@ lw_dist2d_seg_seg(const POINT2D *A, const POINT2D *B, const POINT2D *C, const PO
 				theP.x = A->x + r * (B->x - A->x);
 				theP.y = A->y + r * (B->y - A->y);
 			}
-			dl->distance = 0.0;
-			dl->p1 = theP;
-			dl->p2 = theP;
+			lw_dist2d_distpts_set(dl, 0, &theP, &theP);
 		}
 		return LW_TRUE;
 	}
@@ -2450,9 +2397,7 @@ lw_dist2d_pt_seg(const POINT2D *p, const POINT2D *A, const POINT2D *B, DISTPTS *
 	/*If the point p is on the segment this is a more robust way to find out that*/
 	if ((((A->y - p->y) * (B->x - A->x) == (A->x - p->x) * (B->y - A->y))) && (dl->mode == DIST_MIN))
 	{
-		dl->distance = 0.0;
-		dl->p1 = *p;
-		dl->p2 = *p;
+		lw_dist2d_distpts_set(dl, 0, p, p);
 	}
 
 

--- a/postgis/liblwgeom/measures.c
+++ b/postgis/liblwgeom/measures.c
@@ -1624,39 +1624,158 @@ lw_dist2d_pt_arc(const POINT2D *P, const POINT2D *A1, const POINT2D *A2, const P
 	return LW_TRUE;
 }
 
-/* Auxiliary function to calculate the distance between 2 concentric arcs*/
-int lw_dist2d_arc_arc_concentric(const POINT2D *A1,
-				 const POINT2D *A2,
-				 const POINT2D *A3,
-				 double radius_A,
-				 const POINT2D *B1,
-				 const POINT2D *B2,
-				 const POINT2D *B3,
-				 double radius_B,
-				 const POINT2D *CENTER,
-				 DISTPTS *dl);
+
+
+/**
+ * @brief Calculates the intersection points of a circle and line.
+ *
+ * This function assumes the center and test point are distinct.
+ * Finds the line between the circle center and test point, and
+ * the two intersection points on the circle defined by that line.
+ * If those points fall within the provided arc (A1,A2,A3) then
+ * the points are added to the provided array (I) and the array
+ * length counter is incremented.
+ *
+ * @param A1   Point of arc
+ * @param A2   Point of arc
+ * @param A3   Point of arc
+ * @param center_A   Center of arc A circle
+ * @param radius_A   Radius of arc A circle
+ * @param P    Point to use in calculating intersection line
+ * @param I    [out] Pointer to an return value array
+ * @param ni   [out] Pointer to return array size counter
+ * @return int
+ */
+static int
+lw_dist2d_circle_intersections(
+	const POINT2D *A1, const POINT2D *A2, const POINT2D *A3,
+	const POINT2D *center_A,
+	double radius_A,
+	const POINT2D *P,
+	POINT2D *I,
+	uint32_t *ni)
+{
+	POINT2D R;
+
+	// If the test point is on the center of the other
+	// arc, some other point has to be closer, by definition.
+	if (p2d_same(center_A, P))
+		return 0;
+
+	// Calculate vector from the center to the pt
+	double dir_x = center_A->x - P->x;
+	double dir_y = center_A->y - P->y;
+	double dist = sqrt(dir_x * dir_x + dir_y * dir_y);
+
+	// Normalize the direction vector to get a unit vector (length = 1)
+	double unit_x = dir_x / dist;
+	double unit_y = dir_y / dist;
+
+	// Calculate the two intersection points on the circle
+	// Point 1: Move from center_A along the unit vector by distance radius_A
+	R.x = center_A->x + unit_x * radius_A;
+	R.y = center_A->y + unit_y * radius_A;
+	if (lw_pt_in_arc(&R, A1, A2, A3))
+		I[(*ni)++] = R;
+
+	// Point 2: Move from center_A against the unit vector by distance radius_A
+	R.x = center_A->x - unit_x * radius_A;
+	R.y = center_A->y - unit_y * radius_A;
+	if (lw_pt_in_arc(&R, A1, A2, A3))
+		I[(*ni)++] = R;
+
+	return 0;
+}
+
+
+/**
+ * @brief Calculates the intersection points of two overlapping circles.
+ *
+ * This function assumes the circles are known to intersect at one or two points.
+ * Specifically, the distance 'd' between their centers must satisfy:
+ * d < (rA + rB)  and  d > fabs(rA - rB)
+ * If these conditions are not met, the results are undefined.
+ *
+ * @param cA   [in] Pointer to the center point of the first circle (A).
+ * @param rA   [in] The radius of the first circle (A).
+ * @param cB   [in] Pointer to the center point of the second circle (B).
+ * @param rB   [in] The radius of the second circle (B).
+ * @param I    [out] Pointer to an array of at least 2 POINT2D structs to store the results.
+ * I[0] will contain the first intersection point.
+ * If a second exists, it will be in I[1].
+ * @return int The number of intersection points found (1 or 2). Returns 0 if
+ * the centers are coincident or another error occurs.
+ */
+static uint32_t
+lw_dist2d_circle_circle_intersections(
+	const POINT2D *cA, double rA,
+	const POINT2D *cB, double rB,
+	POINT2D *I)
+{
+	// Vector from center A to center B
+	double dx = cB->x - cA->x;
+	double dy = cB->y - cA->y;
+
+	// Distance between the centers
+	double d = sqrt(dx * dx + dy * dy);
+
+	// 'a' is the distance from the center of circle A to the point P,
+	// which is the base of the right triangle formed by cA, P, and an intersection point.
+	double a = (rA * rA - rB * rB + d * d) / (2.0 * d);
+
+	// 'h' is the height of that right triangle.
+	double h_squared = rA * rA - a * a;
+
+	// Due to floating point errors, h_squared can be slightly negative.
+	// This happens when the circles are perfectly tangent. Clamp to 0.
+	if (h_squared < 0.0)
+		h_squared = 0.0;
+
+	double h = sqrt(h_squared);
+
+	// Find the coordinates of point P
+	double Px = cA->x + a * (dx / d);
+	double Py = cA->y + a * (dy / d);
+
+	// The two intersection points are found by moving from P by a distance 'h'
+	// in directions perpendicular to the line connecting the centers.
+	// The perpendicular vector to (dx, dy) is (-dy, dx).
+
+	// Intersection point 1
+	I[0].x = Px - h * (dy / d);
+	I[0].y = Py + h * (dx / d);
+
+	// If h is very close to 0, the circles are tangent and there's only one intersection point.
+	if (FP_IS_ZERO(h))
+		return 1;
+
+	// Intersection point 2
+	I[1].x = Px + h * (dy / d);
+	I[1].y = Py - h * (dx / d);
+
+	return 2;
+}
+
 
 int
-lw_dist2d_arc_arc(const POINT2D *A1,
-		  const POINT2D *A2,
-		  const POINT2D *A3,
-		  const POINT2D *B1,
-		  const POINT2D *B2,
-		  const POINT2D *B3,
-		  DISTPTS *dl)
+lw_dist2d_arc_arc(
+	const POINT2D *A1, const POINT2D *A2, const POINT2D *A3,
+	const POINT2D *B1, const POINT2D *B2, const POINT2D *B3,
+	DISTPTS *dl)
 {
-	POINT2D CA, CB;               /* Center points of arcs A and B */
+	POINT2D pts_A[16];            /* Points on A that might be the nearest */
+	POINT2D pts_B[16];            /* Points on B that might be the nearest */
+	uint32_t ai = 0, bi = 0;      /* Number of points in pts_A and pts_B */
+	POINT2D center_A, center_B;   /* Center points of arcs A and B */
 	double radius_A, radius_B, d; /* Radii of arcs A and B */
-	POINT2D D;                    /* Mid-point between the centers CA and CB */
-	int pt_in_arc_A, pt_in_arc_B; /* Test whether potential intersection point is within the arc */
+	int is_disjoint, is_overlapping, is_contained, is_same_center;
+	POINT2D intersectionPts[2];
 
 	if (dl->mode != DIST_MIN)
 	{
 		lwerror("lw_dist2d_arc_arc only supports mindistance");
 		return LW_FALSE; /* MEOS */
 	}
-
-	/* TODO: Handle case where arc is closed circle (A1 = A3) */
 
 	/* What if one or both of our "arcs" is actually a point? */
 	if (lw_arc_is_pt(B1, B2, B3) && lw_arc_is_pt(A1, A2, A3))
@@ -1667,8 +1786,8 @@ lw_dist2d_arc_arc(const POINT2D *A1,
 		return lw_dist2d_pt_arc(A1, B1, B2, B3, dl);
 
 	/* Calculate centers and radii of circles. */
-	radius_A = lw_arc_center(A1, A2, A3, &CA);
-	radius_B = lw_arc_center(B1, B2, B3, &CB);
+	radius_A = lw_arc_center(A1, A2, A3, &center_A);
+	radius_B = lw_arc_center(B1, B2, B3, &center_B);
 
 	/* Two co-linear arcs?!? That's two segments. */
 	if (radius_A < 0 && radius_B < 0)
@@ -1682,275 +1801,112 @@ lw_dist2d_arc_arc(const POINT2D *A1,
 	if (radius_B < 0)
 		return lw_dist2d_seg_arc(B1, B3, A1, A2, A3, dl);
 
-	/* Center-center distance */
-	d = distance2d_pt_pt(&CA, &CB);
+	/* Circle relationships */
+	d = distance2d_pt_pt(&center_A, &center_B);
+	is_disjoint = (d > (radius_A + radius_B));
+	is_contained = (d < fabs(radius_A - radius_B));
+	is_same_center = p2d_same(&center_A, &center_B);
+	is_overlapping = ! (is_disjoint || is_contained || is_same_center);
 
-	/* Concentric arcs */
-	if (FP_EQUALS(d, 0.0))
-		return lw_dist2d_arc_arc_concentric(A1, A2, A3, radius_A, B1, B2, B3, radius_B, &CA, dl);
+	/*
+	 * Prime the array of potential closest points with the
+	 * arc end points, which frequently participate in closest
+	 * points.
+	 */
+	pts_A[ai++] = *A1;
+	pts_A[ai++] = *A3;
+	pts_B[bi++] = *B1;
+	pts_B[bi++] = *B3;
 
-	/* Make sure that arc "A" has the bigger radius */
-	if (radius_B > radius_A)
+	/*
+	 * Overlapping circles might have a zero distance
+	 * case if the circle intersection points are inside both
+	 * arcs.
+	 */
+	if (is_overlapping)
 	{
-		const POINT2D *tmp;
-		POINT2D TP; /* Temporary point P */
-		double td;
-		tmp = B1;
-		B1 = A1;
-		A1 = tmp;
-		tmp = B2;
-		B2 = A2;
-		A2 = tmp;
-		tmp = B3;
-		B3 = A3;
-		A3 = tmp;
-		TP = CB;
-		CB = CA;
-		CA = TP;
-		td = radius_B;
-		radius_B = radius_A;
-		radius_A = td;
-	}
-
-	/* Circles touch at a point. Is that point within the arcs? */
-	if (d == (radius_A + radius_B))
-	{
-		D.x = CA.x + (CB.x - CA.x) * radius_A / d;
-		D.y = CA.y + (CB.y - CA.y) * radius_A / d;
-
-		pt_in_arc_A = lw_pt_in_arc(&D, A1, A2, A3);
-		pt_in_arc_B = lw_pt_in_arc(&D, B1, B2, B3);
-
-		/* Arcs do touch at D, return it */
-		if (pt_in_arc_A && pt_in_arc_B)
+		/*
+		 * Find the two points the circles intersect at.
+		 */
+		uint32_t npoints = lw_dist2d_circle_circle_intersections(
+			&center_A, radius_A,
+			&center_B, radius_B,
+			intersectionPts);
+		for (uint32_t i = 0; i < npoints; i++)
 		{
-			lw_dist2d_distpts_set(dl, 0.0, &D, &D);
-			return LW_TRUE;
+			/*
+			 * If an intersection point is contained in both
+			 * arcs, that is a location of zero distance, so
+			 * we are done calculating.
+			 */
+			if (lw_pt_in_arc(&intersectionPts[i], A1, A2, A3) &&
+				lw_pt_in_arc(&intersectionPts[i], B1, B2, B3))
+			{
+				lw_dist2d_distpts_set(dl, 0.0, &intersectionPts[i], &intersectionPts[i]);
+				return LW_TRUE;
+			}
 		}
 	}
-	/* Disjoint or contained circles don't intersect. Closest point may be on */
-	/* the line joining CA to CB. */
-	else if (d > (radius_A + radius_B) /* Disjoint */ || d < (radius_A - radius_B) /* Contained */)
+
+	/*
+	 * Join the circle centers and find the places that
+	 * line intersects the circles. Where those places
+	 * are in the arcs, they are potential sites of the
+	 * closest points.
+	 */
+	if (is_disjoint || is_contained || is_overlapping)
 	{
-		POINT2D XA, XB; /* Points where the line from CA to CB cross their circle bounds */
-
-		/* Calculate hypothetical nearest points, the places on the */
-		/* two circles where the center-center line crosses. If both */
-		/* arcs contain their hypothetical points, that's the crossing distance */
-		XA.x = CA.x + (CB.x - CA.x) * radius_A / d;
-		XA.y = CA.y + (CB.y - CA.y) * radius_A / d;
-		XB.x = CB.x + (CA.x - CB.x) * radius_B / d;
-		XB.y = CB.y + (CA.y - CB.y) * radius_B / d;
-
-		pt_in_arc_A = lw_pt_in_arc(&XA, A1, A2, A3);
-		pt_in_arc_B = lw_pt_in_arc(&XB, B1, B2, B3);
-
-		/* If the nearest points are both within the arcs, that's our answer */
-		/* the shortest distance is at the nearest points */
-		if (pt_in_arc_A && pt_in_arc_B)
+		if (!is_same_center)
 		{
-			return lw_dist2d_pt_pt(&XA, &XB, dl);
-		}
-	}
-	/* Circles cross at two points, are either of those points in both arcs? */
-	/* http://paulbourke.net/geometry/2circle/ */
-	else if (d < (radius_A + radius_B))
-	{
-		POINT2D E, F; /* Points where circle(A) and circle(B) cross */
-		/* Distance from CA to D */
-		double a = (radius_A * radius_A - radius_B * radius_B + d * d) / (2 * d);
-		/* Distance from D to E or F */
-		double h = sqrt(radius_A * radius_A - a * a);
+			/* Add points on A that intersect line from center_A to center_B */
+			lw_dist2d_circle_intersections(
+			    A1, A2, A3,
+			    &center_A, radius_A, &center_B,
+			    pts_A, &ai);
 
-		/* Location of D */
-		D.x = CA.x + (CB.x - CA.x) * a / d;
-		D.y = CA.y + (CB.y - CA.y) * a / d;
-
-		/* Start from D and project h units perpendicular to CA-D to get E */
-		E.x = D.x + (D.y - CA.y) * h / a;
-		E.y = D.y + (D.x - CA.x) * h / a;
-
-		/* Crossing point E contained in arcs? */
-		pt_in_arc_A = lw_pt_in_arc(&E, A1, A2, A3);
-		pt_in_arc_B = lw_pt_in_arc(&E, B1, B2, B3);
-
-		if (pt_in_arc_A && pt_in_arc_B)
-		{
-			lw_dist2d_distpts_set(dl, 0.0, &E, &E);
-			return LW_TRUE;
+			/* Add points on B that intersect line from center_B to center_A */
+			lw_dist2d_circle_intersections(
+			    B1, B2, B3,
+			    &center_B, radius_B, &center_A,
+			    pts_B, &bi);
 		}
 
-		/* Start from D and project h units perpendicular to CA-D to get F */
-		F.x = D.x - (D.y - CA.y) * h / a;
-		F.y = D.y - (D.x - CA.x) * h / a;
+		/* Add points on A that intersect line to B1 */
+		lw_dist2d_circle_intersections(
+		    A1, A2, A3,
+		    &center_A, radius_A, B1,
+		    pts_A, &ai);
 
-		/* Crossing point F contained in arcs? */
-		pt_in_arc_A = lw_pt_in_arc(&F, A1, A2, A3);
-		pt_in_arc_B = lw_pt_in_arc(&F, B1, B2, B3);
+		/* Add points on A that intersect line to B3 */
+		lw_dist2d_circle_intersections(
+		    A1, A2, A3,
+		    &center_A, radius_A, B3,
+		    pts_A, &ai);
 
-		if (pt_in_arc_A && pt_in_arc_B)
-		{
-			lw_dist2d_distpts_set(dl, 0.0, &F, &F);
-			return LW_TRUE;
-		}
-	}
-	else
-	{
-		lwerror("lw_dist2d_arc_arc: arcs neither touch, intersect nor are disjoint! INCONCEIVABLE!");
-		return LW_FALSE;
+		/* Add points on B that intersect line to A1 */
+		lw_dist2d_circle_intersections(
+		    B1, B2, B3,
+		    &center_B, radius_B, A1,
+		    pts_B, &bi);
+
+		/* Add points on B that intersect line to A3 */
+		lw_dist2d_circle_intersections(
+		    B1, B2, B3,
+		    &center_B, radius_B, A3,
+		    pts_B, &bi);
 	}
 
-	/* Closest point is in the arc A, but not in the arc B, so */
-	/* one of the B end points must be the closest. */
-	if (pt_in_arc_A && !pt_in_arc_B)
-	{
-		lw_dist2d_pt_arc(B1, A1, A2, A3, dl);
-		lw_dist2d_pt_arc(B3, A1, A2, A3, dl);
-		return LW_TRUE;
-	}
-	/* Closest point is in the arc B, but not in the arc A, so */
-	/* one of the A end points must be the closest. */
-	else if (pt_in_arc_B && !pt_in_arc_A)
-	{
-		lw_dist2d_pt_arc(A1, B1, B2, B3, dl);
-		lw_dist2d_pt_arc(A3, B1, B2, B3, dl);
-		return LW_TRUE;
-	}
-	/* Finally, one of the end-point to end-point combos is the closest. */
-	else
-	{
-		lw_dist2d_pt_pt(A1, B1, dl);
-		lw_dist2d_pt_pt(A1, B3, dl);
-		lw_dist2d_pt_pt(A3, B1, dl);
-		lw_dist2d_pt_pt(A3, B3, dl);
-		return LW_TRUE;
-	}
+	/*
+	 * Now just brute force check all pairs of participating
+	 * points, to find the pair that is closest together.
+	 */
+	for (uint32_t i = 0; i < ai; i++)
+		for (uint32_t j = 0; j < bi; j++)
+			lw_dist2d_pt_pt(&pts_A[i], &pts_B[j], dl);
 
 	return LW_TRUE;
 }
 
-int
-lw_dist2d_arc_arc_concentric(const POINT2D *A1,
-			     const POINT2D *A2,
-			     const POINT2D *A3,
-			     double radius_A,
-			     const POINT2D *B1,
-			     const POINT2D *B2,
-			     const POINT2D *B3,
-			     double radius_B,
-			     const POINT2D *CENTER,
-			     DISTPTS *dl)
-{
-	int seg_size;
-	double dist_sqr, shortest_sqr;
-	const POINT2D *P1;
-	const POINT2D *P2;
-	POINT2D proj;
-
-	if (radius_A == radius_B)
-	{
-		/* Check if B1 or B3 are in the same side as A2 in the A1-A3 arc */
-		seg_size = lw_segment_side(A1, A3, A2);
-		if (seg_size == lw_segment_side(A1, A3, B1))
-		{
-			lw_dist2d_distpts_set(dl, 0.0, B1, B1);
-			return LW_TRUE;
-		}
-		if (seg_size == lw_segment_side(A1, A3, B3))
-		{
-			lw_dist2d_distpts_set(dl, 0.0, B3, B3);
-			return LW_TRUE;
-		}
-		/* Check if A1 or A3 are in the same side as B2 in the B1-B3 arc */
-		seg_size = lw_segment_side(B1, B3, B2);
-		if (seg_size == lw_segment_side(B1, B3, A1))
-		{
-			lw_dist2d_distpts_set(dl, 0.0, A1, A1);
-			return LW_TRUE;
-		}
-		if (seg_size == lw_segment_side(B1, B3, A3))
-		{
-			lw_dist2d_distpts_set(dl, 0.0, A3, A3);
-			return LW_TRUE;
-		}
-	}
-	else
-	{
-		/* Check if any projection of B ends are in A*/
-		seg_size = lw_segment_side(A1, A3, A2);
-
-		/* B1 */
-		proj.x = CENTER->x + (B1->x - CENTER->x) * radius_A / radius_B;
-		proj.y = CENTER->y + (B1->y - CENTER->y) * radius_A / radius_B;
-
-		if (seg_size == lw_segment_side(A1, A3, &proj))
-		{
-			lw_dist2d_distpts_set(dl, fabs(radius_A - radius_B), &proj, B1);
-			return LW_TRUE;
-		}
-		/* B3 */
-		proj.x = CENTER->x + (B3->x - CENTER->x) * radius_A / radius_B;
-		proj.y = CENTER->y + (B3->y - CENTER->y) * radius_A / radius_B;
-		if (seg_size == lw_segment_side(A1, A3, &proj))
-		{
-			lw_dist2d_distpts_set(dl, fabs(radius_A - radius_B), &proj, B3);
-			return LW_TRUE;
-		}
-
-		/* Now check projections of A in B */
-		seg_size = lw_segment_side(B1, B3, B2);
-
-		/* A1 */
-		proj.x = CENTER->x + (A1->x - CENTER->x) * radius_B / radius_A;
-		proj.y = CENTER->y + (A1->y - CENTER->y) * radius_B / radius_A;
-		if (seg_size == lw_segment_side(B1, B3, &proj))
-		{
-			lw_dist2d_distpts_set(dl, fabs(radius_A - radius_B), &proj, A1);
-			return LW_TRUE;
-		}
-
-		/* A3 */
-		proj.x = CENTER->x + (A3->x - CENTER->x) * radius_B / radius_A;
-		proj.y = CENTER->y + (A3->y - CENTER->y) * radius_B / radius_A;
-		if (seg_size == lw_segment_side(B1, B3, &proj))
-		{
-			lw_dist2d_distpts_set(dl, fabs(radius_A - radius_B), &proj, A3);
-			return LW_TRUE;
-		}
-	}
-
-	/* Check the shortest between the distances of the 4 ends */
-	shortest_sqr = dist_sqr = distance2d_sqr_pt_pt(A1, B1);
-	P1 = A1;
-	P2 = B1;
-
-	dist_sqr = distance2d_sqr_pt_pt(A1, B3);
-	if (dist_sqr < shortest_sqr)
-	{
-		shortest_sqr = dist_sqr;
-		P1 = A1;
-		P2 = B3;
-	}
-
-	dist_sqr = distance2d_sqr_pt_pt(A3, B1);
-	if (dist_sqr < shortest_sqr)
-	{
-		shortest_sqr = dist_sqr;
-		P1 = A3;
-		P2 = B1;
-	}
-
-	dist_sqr = distance2d_sqr_pt_pt(A3, B3);
-	if (dist_sqr < shortest_sqr)
-	{
-		shortest_sqr = dist_sqr;
-		P1 = A3;
-		P2 = B3;
-	}
-
-	lw_dist2d_distpts_set(dl, sqrt(shortest_sqr), P1, P2);
-	return LW_TRUE;
-}
 
 /**
 Finds the shortest distance between two segments.

--- a/postgis/liblwgeom/measures.c
+++ b/postgis/liblwgeom/measures.c
@@ -1524,7 +1524,6 @@ lw_dist2d_seg_arc(const POINT2D *A1,
 	{
 		lw_dist2d_pt_arc(A1, B1, B2, B3, dl);
 		lw_dist2d_pt_arc(A2, B1, B2, B3, dl);
-		return LW_TRUE;
 	}
 	/* or, one of the arc end points is the closest */
 	else if (pt_in_seg && !pt_in_arc)
@@ -1536,7 +1535,6 @@ lw_dist2d_seg_arc(const POINT2D *A1,
 		lw_dist2d_pt_seg(B1, A1, A2, dl);
 		lw_dist2d_pt_seg(B3, A1, A2, dl);
 		dl->twisted = -dl->twisted;
-		return LW_TRUE;
 	}
 	/* Finally, one of the end-point to end-point combos is the closest. */
 	else
@@ -1545,10 +1543,29 @@ lw_dist2d_seg_arc(const POINT2D *A1,
 		lw_dist2d_pt_pt(A1, B3, dl);
 		lw_dist2d_pt_pt(A2, B1, dl);
 		lw_dist2d_pt_pt(A2, B3, dl);
-		return LW_TRUE;
 	}
 
-	return LW_FALSE;
+	/* MEOS: the flags above are read on one crossing or on one point, and do
+	 * not rule the other candidates out. Where the segment and the arc do not
+	 * cross, and the pair of the circle point nearest the line and its foot
+	 * does not lie on both, the closest points hold an end of the segment or
+	 * an end of the arc, so every one of those four candidates is measured,
+	 * but for the two the family above has measured; each replaces the
+	 * answer only where it is strictly nearer, so the family keeps the answer
+	 * it gives on a tie */
+	if (! (pt_in_arc && !pt_in_seg))
+	{
+		lw_dist2d_pt_arc(A1, B1, B2, B3, dl);
+		lw_dist2d_pt_arc(A2, B1, B2, B3, dl);
+	}
+	if (! (pt_in_seg && !pt_in_arc))
+	{
+		dl->twisted = -dl->twisted;
+		lw_dist2d_pt_seg(B1, A1, A2, dl);
+		lw_dist2d_pt_seg(B3, A1, A2, dl);
+		dl->twisted = -dl->twisted;
+	}
+	return LW_TRUE;
 }
 
 /* MEOS: record a distance computed apart from its two points, in the order

--- a/postgis/liblwgeom/measures.c
+++ b/postgis/liblwgeom/measures.c
@@ -293,6 +293,39 @@ lw_dist2d_check_overlap(const LWGEOM *lwg1, const LWGEOM *lwg2)
 	return LW_TRUE;
 }
 
+/* MEOS: the largest magnitude of a coordinate of a box */
+static inline double
+lw_dist2d_gbox_reach(const GBOX *b)
+{
+	return FP_MAX(FP_MAX(fabs(b->xmin), fabs(b->xmax)),
+		FP_MAX(fabs(b->ymin), fabs(b->ymax)));
+}
+
+/* MEOS: whether two boxes lie further apart than a distance already found,
+ * reach bounding the magnitude of their coordinates. Every distance the walk
+ * computes between what the boxes hold is at least the distance between the
+ * boxes, up to the rounding of the boxes and of the distance itself, which
+ * the margin covers. A pair apart in that sense cannot return a distance
+ * below the one found, and the walk replaces its answer only with a strictly
+ * smaller one, so skipping the pair leaves both the distance and the pair of
+ * points it is read from as the full walk finds them */
+static inline int
+lw_dist2d_gbox_apart(const GBOX *b1, const GBOX *b2, double dist, double reach)
+{
+	double dx = FP_MAX(0.0, FP_MAX(b1->xmin - b2->xmax, b2->xmin - b1->xmax));
+	double dy = FP_MAX(0.0, FP_MAX(b1->ymin - b2->ymax, b2->ymin - b1->ymax));
+	double lim = dist + 16 * DBL_EPSILON * (dist + reach);
+	return dx * dx + dy * dy > lim * lim;
+}
+
+/* MEOS: whether two parts lie further apart than a distance already found */
+static int
+lw_dist2d_boxes_apart(const GBOX *b1, const GBOX *b2, double dist)
+{
+	return lw_dist2d_gbox_apart(b1, b2, dist,
+		FP_MAX(lw_dist2d_gbox_reach(b1), lw_dist2d_gbox_reach(b2)));
+}
+
 /**
 This is a recursive function delivering every possible combination of subgeometries
 */
@@ -367,6 +400,15 @@ lw_dist2d_recursive(const LWGEOM *lwg1, const LWGEOM *lwg2, DISTPTS *dl)
 
 			/* If one of geometries is empty, skip */
 			if (lwgeom_is_empty(g1) || lwgeom_is_empty(g2))
+				continue;
+
+			/* MEOS: a pair further apart than the distance found holds no
+			 * nearer pair of points. Nothing is skipped once the distance is
+			 * within the tolerance: a pair the full walk measures then can
+			 * still set the points it reports */
+			if (dl->mode == DIST_MIN && dl->distance > dl->tolerance &&
+			    g1->bbox && g2->bbox &&
+			    lw_dist2d_boxes_apart(g1->bbox, g2->bbox, dl->distance))
 				continue;
 
 			if ((dl->mode != DIST_MAX) && (!lw_dist2d_check_overlap(g1, g2)) &&

--- a/postgis/liblwgeom/measures.h
+++ b/postgis/liblwgeom/measures.h
@@ -69,7 +69,6 @@ typedef struct
 int lw_dist2d_comp(const LWGEOM *lw1, const LWGEOM *lw2, DISTPTS *dl);
 int lw_dist2d_distribute_bruteforce(const LWGEOM *lwg1, const LWGEOM *lwg2, DISTPTS *dl);
 int lw_dist2d_recursive(const LWGEOM *lwg1, const LWGEOM *lwg2, DISTPTS *dl);
-int lw_dist2d_check_overlap(LWGEOM *lwg1, LWGEOM *lwg2);
 int lw_dist2d_distribute_fast(LWGEOM *lwg1, LWGEOM *lwg2, DISTPTS *dl);
 
 /*

--- a/postgis/liblwgeom/ptarray.c
+++ b/postgis/liblwgeom/ptarray.c
@@ -1057,11 +1057,17 @@ ptarray_contains_point_partial(const POINTARRAY *pa, const POINT2D *pt, int chec
 	const POINT2D *seg1, *seg2;
 	double ymin, ymax;
 
+	if ( !pa || !pa->npoints )
+	{
+		lwerror("%s called on empty pointarray", __func__);
+		return LW_OUTSIDE; /* MEOS */
+	}
+
 	seg1 = getPoint2d_cp(pa, 0);
 	seg2 = getPoint2d_cp(pa, pa->npoints-1);
 	if ( check_closed && ! p2d_same(seg1, seg2) )
 	{
-		lwerror("ptarray_contains_point called on unclosed ring");
+		lwerror("%s called on unclosed ring", __func__);
 		return LW_OUTSIDE; /* MEOS */
 	}
 

--- a/postgis/liblwgeom/ptarray.c
+++ b/postgis/liblwgeom/ptarray.c
@@ -745,17 +745,297 @@ ptarray_is_closed_z(const POINTARRAY *in)
 }
 
 /**
-* Return LW_INSIDE if the point is inside the POINTARRAY,
-* LW_OUTSIDE if it is outside, and LW_BOUNDARY if it is on
-* the boundary.
-* LW_INSIDE == 1, LW_BOUNDARY == 0, LW_OUTSIDE == -1
-*/
+ * The following is based on the "Fast Winding Number Inclusion of a Point
+ * in a Polygon" algorithm by Dan Sunday.
+ * http://softsurfer.com/Archive/algorithm_0103/algorithm_0103.htm#Winding%20Number
+ *
+ * Return:
+ *  - LW_INSIDE (1) if the point is inside the POINTARRAY
+ *  - LW_BOUNDARY (0) if it is on the boundary.
+ *  - LW_OUTSIDE (-1) if it is outside
+ */
 int
 ptarray_contains_point(const POINTARRAY *pa, const POINT2D *pt)
 {
-	return ptarray_contains_point_partial(pa, pt, LW_TRUE, NULL);
+	const POINT2D *seg1, *seg2;
+	int wn = 0;
+
+	seg1 = getPoint2d_cp(pa, 0);
+	seg2 = getPoint2d_cp(pa, pa->npoints-1);
+	if (!p2d_same(seg1, seg2))
+	{
+		lwerror("ptarray_contains_point called on unclosed ring");
+		return LW_OUTSIDE; /* MEOS */
+	}
+
+	for (uint32_t i = 1; i < pa->npoints; i++)
+	{
+		double side, ymin, ymax;
+
+		seg2 = getPoint2d_cp(pa, i);
+
+		/* Zero length segments are ignored. */
+		if (p2d_same(seg1, seg2))
+		{
+			seg1 = seg2;
+			continue;
+		}
+
+		ymin = FP_MIN(seg1->y, seg2->y);
+		ymax = FP_MAX(seg1->y, seg2->y);
+
+		/* Only test segments in our vertical range */
+		if (pt->y > ymax || pt->y < ymin)
+		{
+			seg1 = seg2;
+			continue;
+		}
+
+		side = lw_segment_side(seg1, seg2, pt);
+
+		/*
+		* A point on the boundary of a ring is not contained.
+		* WAS: if (fabs(side) < 1e-12), see #852
+		*/
+		if ((side == 0) && lw_pt_in_seg(pt, seg1, seg2))
+		{
+			return LW_BOUNDARY;
+		}
+
+		/*
+		* If the point is to the left of the line, and it's rising,
+		* then the line is to the right of the point and
+		* circling counter-clockwise, so increment.
+		*/
+		if ((side < 0) && (seg1->y <= pt->y) && (pt->y < seg2->y))
+		{
+			wn++;
+		}
+
+		/*
+		* If the point is to the right of the line, and it's falling,
+		* then the line is to the right of the point and circling
+		* clockwise, so decrement.
+		*/
+		else if ( (side > 0) && (seg2->y <= pt->y) && (pt->y < seg1->y) )
+		{
+			wn--;
+		}
+
+		seg1 = seg2;
+	}
+
+	/* wn == 0 => Outside, wn != 0 => Inside */
+	return wn == 0 ? LW_OUTSIDE : LW_INSIDE;
 }
 
+int
+ptarray_raycast_intersections(const POINTARRAY *pa, const POINT2D *p, int *on_boundary)
+{
+	// A valid linestring must have at least 2 point
+	if (pa->npoints < 2)
+	{
+		lwerror("%s called on invalid linestring", __func__);
+		return 0; /* MEOS */
+	}
+
+	int intersections = 0;
+	double px = p->x;
+	double py = p->y;
+
+	// Iterate through each edge of the polygon
+	for (uint32_t i = 0; i < pa->npoints-1; ++i)
+	{
+		const POINT2D* p1 = getPoint2d_cp(pa, i);
+		const POINT2D* p2 = getPoint2d_cp(pa, i+1);
+
+		/* Skip zero-length edges */
+		if (p2d_same(p1, p2))
+			continue;
+
+		/* --- Step 1: Check if the point is ON the boundary edge --- */
+		if (lw_pt_on_segment(p1, p2, p))
+		{
+			*on_boundary = LW_TRUE;
+			return 0;
+		}
+
+		/* --- Step 2: Perform the Ray Casting intersection test --- */
+
+		/*
+		 * Check if the horizontal ray from p intersects the edge (p1, p2).
+		 * This is the core condition for handling vertices correctly:
+		 *   - One vertex must be strictly above the ray (py < vertex.y)
+		 *   - The other must be on or below the ray (py >= vertex.y)
+		 */
+		if (((p1->y <= py) && (py < p2->y)) || ((p2->y <= py) && (py < p1->y)))
+		{
+			/*
+			 * Calculate the x-coordinate where the edge intersects the ray's horizontal line.
+			 * Formula: x = x1 + (y - y1) * (x2 - x1) / (y2 - y1)
+			 */
+			double x_intersection = p1->x + (py - p1->y) * (p2->x - p1->x) / (p2->y - p1->y);
+
+			/*
+			 * If the intersection point is to the right of our test point,
+			 * it's a valid "crossing".
+			 */
+			if (x_intersection > px)
+			{
+				intersections++;
+			}
+		}
+	}
+
+	return intersections;
+}
+
+
+/**
+ * @brief Calculates the intersection points of a circle and a horizontal line.
+ *
+ * The equation of a circle is (x - cx)^2 + (y - cy)^2 = r^2.
+ * The equation of the horizontal line is y = y_line.
+ * Substituting y_line into the circle equation gives:
+ * (x - cx)^2 = r^2 - (y_line - cy)^2
+ * This function solves for x.
+ *
+ * @param center A pointer to the center point of the circle.
+ * @param radius The radius of the circle.
+ * @param ray The y-coordinate of the horizontal line.
+ * @param i0 A pointer to a POINT2D to store the first intersection point.
+ * @param i1 A pointer to a POINT2D to store the second intersection point.
+ *
+ * @return The number of intersection points found (0, 1, or 2).
+ */
+static int
+circle_raycast_intersections(const POINT2D *center, double radius, double ray, POINT2D *i0, POINT2D *i1)
+{
+	// Calculate the vertical distance from the circle's center to the horizontal line.
+	double dy = ray - center->y;
+
+	// If the absolute vertical distance is greater than the radius, there are no intersections.
+	if (fabs(dy) > radius)
+		return 0;
+
+	// Use the Pythagorean theorem to find the horizontal distance (dx) from the
+	// center's x-coordinate to the intersection points.
+	// dx^2 + dy^2 = radius^2  =>  dx^2 = radius^2 - dy^2
+	double dx_squared = radius * radius - dy * dy;
+
+	// Case 1: One intersection (tangent)
+	// This occurs when the line just touches the top or bottom of the circle.
+	// dx_squared will be zero. We check against a small epsilon for floating-point safety.
+	if (FP_EQUALS(dx_squared, 0.0))
+	{
+		i0->x = center->x;
+		i0->y = ray;
+		return 1;
+	}
+
+	// Case 2: Two intersections
+	// The line cuts through the circle.
+	double dx = sqrt(dx_squared);
+
+	// The first intersection point has the smaller x-value.
+	i0->x = center->x - dx;
+	i0->y = ray;
+
+	// The second intersection point has the larger x-value.
+	i1->x = center->x + dx;
+	i1->y = ray;
+
+	return 2;
+}
+
+
+int
+ptarrayarc_raycast_intersections(const POINTARRAY *pa, const POINT2D *p, int *on_boundary)
+{
+	int intersections = 0;
+	double px = p->x;
+	double py = p->y;
+
+	assert(on_boundary);
+
+	// A valid circular arc must have at least 3 vertices (circle).
+	if (pa->npoints < 3)
+	{
+		lwerror("%s called on invalid circularstring", __func__);
+		return 0; /* MEOS */
+	}
+
+	if (pa->npoints % 2 == 0)
+	{
+		lwerror("%s called with even number of points", __func__);
+		return 0; /* MEOS */
+	}
+
+	// Iterate through each arc of the circularstring
+	for (uint32_t i = 1; i < pa->npoints-1; i +=2)
+	{
+		const POINT2D* p0 = getPoint2d_cp(pa, i-1);
+		const POINT2D* p1 = getPoint2d_cp(pa, i);
+		const POINT2D* p2 = getPoint2d_cp(pa, i+1);
+		POINT2D center = {0,0};
+		double radius, d;
+		GBOX gbox;
+
+		// Skip zero-length arc
+		if (lw_arc_is_pt(p0, p1, p2))
+			continue;
+
+		// --- Step 1: Check if the point is ON the boundary edge ---
+		if (p2d_same(p0, p) || p2d_same(p1, p) || p2d_same(p2, p))
+		{
+			*on_boundary = LW_TRUE;
+			return 0;
+		}
+
+		// Calculate some important pieces
+		radius = lw_arc_center(p0, p1, p2, &center);
+
+		d = distance2d_pt_pt(p, &center);
+		if (FP_EQUALS(d, radius) && lw_pt_in_arc(p, p0, p1, p2))
+		{
+			*on_boundary = LW_TRUE;
+			return 0;
+		}
+
+		// --- Step 2: Perform the Ray Casting intersection test ---
+
+		// Only process arcs that our ray crosses
+		lw_arc_calculate_gbox_cartesian_2d(p0, p1, p2, &gbox);
+		if ((gbox.ymin <= py) && (py < gbox.ymax))
+		{
+			// Point of intersection on the circle that defines the arc
+			POINT2D i0, i1;
+
+			// How many points of intersection are there
+			int iCount = circle_raycast_intersections(&center, radius, py, &i0, &i1);
+
+			// Nothing to see here
+			if (iCount == 0)
+				continue;
+
+			// Cannot think of a case where a grazing is not a
+			// no-op
+			if (iCount == 1)
+				continue;
+
+			// So we must have 2 intersections
+			// Only increment the counter for intersections to the right
+			// of the test point
+			if (i0.x > px && lw_pt_in_arc(&i0, p0, p1, p2))
+				intersections++;
+
+			if (i1.x > px && lw_pt_in_arc(&i1, p0, p1, p2))
+				intersections++;
+		}
+	}
+
+	return intersections;
+}
 
 /*
  * The following is based on the "Fast Winding Number Inclusion of a Point
@@ -768,8 +1048,7 @@ ptarray_contains_point_partial(const POINTARRAY *pa, const POINT2D *pt, int chec
 	int wn = 0;
 	uint32_t i;
 	double side;
-	const POINT2D *seg1;
-	const POINT2D *seg2;
+	const POINT2D *seg1, *seg2;
 	double ymin, ymax;
 
 	seg1 = getPoint2d_cp(pa, 0);
@@ -861,160 +1140,19 @@ ptarray_contains_point_partial(const POINTARRAY *pa, const POINT2D *pt, int chec
 int
 ptarrayarc_contains_point(const POINTARRAY *pa, const POINT2D *pt)
 {
-	return ptarrayarc_contains_point_partial(pa, pt, LW_TRUE /* Check closed*/, NULL);
-}
-
-int
-ptarrayarc_contains_point_partial(const POINTARRAY *pa, const POINT2D *pt, int check_closed, int *winding_number)
-{
-	int wn = 0;
-	uint32_t i;
-	int side;
-	const POINT2D *seg1;
-	const POINT2D *seg2;
-	const POINT2D *seg3;
-	GBOX gbox;
-
-	/* Check for not an arc ring (always have odd # of points) */
-	if ( (pa->npoints % 2) == 0 )
+	int on_boundary = LW_FALSE;
+	int intersections;
+	if (!ptarray_is_closed_2d(pa))
 	{
-		lwerror("ptarrayarc_contains_point called with even number of points");
-		return LW_OUTSIDE;
+		lwerror("%s called on unclosed ring", __func__);
+		return LW_OUTSIDE; /* MEOS */
 	}
 
-	/* Check for not an arc ring (always have >= 3 points) */
-	if ( pa->npoints < 3 )
-	{
-		lwerror("ptarrayarc_contains_point called too-short pointarray");
-		return LW_OUTSIDE;
-	}
-
-	/* Check for unclosed case */
-	seg1 = getPoint2d_cp(pa, 0);
-	seg3 = getPoint2d_cp(pa, pa->npoints-1);
-	if ( check_closed && ! p2d_same(seg1, seg3) )
-	{
-		lwerror("ptarrayarc_contains_point called on unclosed ring");
-		return LW_OUTSIDE;
-	}
-	/* OK, it's closed. Is it just one circle? */
-	else if ( p2d_same(seg1, seg3) && pa->npoints == 3 )
-	{
-		double radius, d;
-		POINT2D c;
-		seg2 = getPoint2d_cp(pa, 1);
-
-		/* Wait, it's just a point, so it can't contain anything */
-		if ( lw_arc_is_pt(seg1, seg2, seg3) )
-			return LW_OUTSIDE;
-
-		/* See if the point is within the circle radius */
-		radius = lw_arc_center(seg1, seg2, seg3, &c);
-		d = distance2d_pt_pt(pt, &c);
-		if ( FP_EQUALS(d, radius) )
-			return LW_BOUNDARY; /* Boundary of circle */
-		else if ( d < radius )
-			return LW_INSIDE; /* Inside circle */
-		else
-			return LW_OUTSIDE; /* Outside circle */
-	}
-	else if ( p2d_same(seg1, pt) || p2d_same(seg3, pt) )
-	{
-		return LW_BOUNDARY; /* Boundary case */
-	}
-
-	/* Start on the ring */
-	seg1 = getPoint2d_cp(pa, 0);
-	for ( i=1; i < pa->npoints; i += 2 )
-	{
-		seg2 = getPoint2d_cp(pa, i);
-		seg3 = getPoint2d_cp(pa, i+1);
-
-		/* Catch an easy boundary case */
-		if( p2d_same(seg3, pt) )
-			return LW_BOUNDARY;
-
-		/* Skip arcs that have no size */
-		if ( lw_arc_is_pt(seg1, seg2, seg3) )
-		{
-			seg1 = seg3;
-			continue;
-		}
-
-		/* Only test segments in our vertical range */
-		lw_arc_calculate_gbox_cartesian_2d(seg1, seg2, seg3, &gbox);
-		if ( pt->y > gbox.ymax || pt->y < gbox.ymin )
-		{
-			seg1 = seg3;
-			continue;
-		}
-
-		/* Outside of horizontal range, and not between end points we also skip */
-		if ( (pt->x > gbox.xmax || pt->x < gbox.xmin) &&
-			 (pt->y > FP_MAX(seg1->y, seg3->y) || pt->y < FP_MIN(seg1->y, seg3->y)) )
-		{
-			seg1 = seg3;
-			continue;
-		}
-
-		side = lw_arc_side(seg1, seg2, seg3, pt);
-
-		/* On the boundary */
-		if ( (side == 0) && lw_pt_in_arc(pt, seg1, seg2, seg3) )
-		{
-			return LW_BOUNDARY;
-		}
-
-		/* Going "up"! Point to left of arc. */
-		if ( side < 0 && (seg1->y <= pt->y) && (pt->y < seg3->y) )
-		{
-			wn++;
-		}
-
-		/* Going "down"! */
-		if ( side > 0 && (seg3->y <= pt->y) && (pt->y < seg1->y) )
-		{
-			wn--;
-		}
-
-		/* Inside the arc! */
-		if ( pt->x <= gbox.xmax && pt->x >= gbox.xmin )
-		{
-			POINT2D C;
-			double radius = lw_arc_center(seg1, seg2, seg3, &C);
-			double d = distance2d_pt_pt(pt, &C);
-
-			/* On the boundary! */
-			if ( d == radius )
-				return LW_BOUNDARY;
-
-			/* Within the arc! */
-			if ( d  < radius )
-			{
-				/* Left side, increment winding number */
-				if ( side < 0 )
-					wn++;
-				/* Right side, decrement winding number */
-				if ( side > 0 )
-					wn--;
-			}
-		}
-
-		seg1 = seg3;
-	}
-
-	/* Sent out the winding number for calls that are building on this as a primitive */
-	if ( winding_number )
-		*winding_number = wn;
-
-	/* Outside */
-	if (wn == 0)
-	{
-		return LW_OUTSIDE;
-	}
-
-	/* Inside */
-	return LW_INSIDE;
+	intersections = ptarrayarc_raycast_intersections(pa, pt, &on_boundary);
+	if (on_boundary)
+		return LW_BOUNDARY;
+	else
+		return (intersections % 2) ? LW_INSIDE : LW_OUTSIDE;
 }
 
 /**

--- a/postgis/liblwgeom/ptarray.c
+++ b/postgis/liblwgeom/ptarray.c
@@ -774,6 +774,12 @@ ptarray_contains_point(const POINTARRAY *pa, const POINT2D *pt)
 
 		seg2 = getPoint2d_cp(pa, i);
 
+		/* This is required for robustness, see #6023 */
+		if (p2d_same(seg1, pt))
+		{
+			return LW_BOUNDARY;
+		}
+
 		/* Zero length segments are ignored. */
 		if (p2d_same(seg1, seg2))
 		{


### PR DESCRIPTION
Keep the nearest answer the distance walk finds in every zero and arc case

Replicates PostGIS commit 524d48ffb5 of the stable-3.6 line, "Ensure DISTPTS
gets updated correctly in arc distance cases" (PostGIS ticket 5991).

The distance walk writes the distance and its two points directly wherever
it answers 0 (a point or a line inside a polygon or a triangle, two segments
crossing, a segment crossing an arc, two arcs crossing or touching) and in
every case of two concentric arcs, so a pair measured later replaces a
nearer answer an earlier pair records. lw_dist2d_distpts_set records a pair
only where it is strictly nearer, and each of those writes goes through it.

The case of lw_dist2d_pt_arc whose point is the centre of the circle keeps
the form MEOS gives it, lw_dist2d_pt_pt_at, which also records a pair only
where it is strictly nearer.


Measure two arcs over the points either can be nearest at

Replicates PostGIS commit be2a0ffda5 of the stable-3.6 line, "Fix arc/arc
distance to handle more cases such as contained, circular, and other
interesting arc/arc alignments that come up rarely in ordinary GIS data",
with its NEWS entry and liblwgeom unit tests left out, as the tree carries
neither.

lw_dist2d_arc_arc reads the distance between two arcs off a set of candidate
points on each: its two ends, the points where the line through the two
centres meets its circle, and the points where the lines from its centre to
the two ends of the other arc meet its circle, each kept where it lies on
the arc. Two arcs whose circles cross answer 0 at a crossing both arcs hold;
otherwise every pair of candidates is measured. The branches this replaces
miss an arc lying inside the circle of the other, and
lw_dist2d_arc_arc_concentric, the branch for arcs on circles sharing a
centre, goes with them.

A point is located in a ring of arcs, and in a compound curve over all of
its parts, by casting a ray and counting the crossings, which reads an arc
the way it reads a segment; a ring of segments keeps the winding number.
lw_pt_in_arc reads a point on the line of the chord as held by the arc,
which on the circle holds only for the two ends.

The new functions that report an error through lwerror return right after
it, as the rest of the vendored liblwgeom does in MEOS, with the value each
answers on failure: 0 crossings for the two ray counts and LW_OUTSIDE for the
three containment tests.


Read a point as on a segment only on its line and between its ends

Replicates PostGIS commit bd6c4c16dc of the stable-3.6 line, "Fix raycast
for linestrings" (PostGIS ticket 5989), with its unit test left out.

lw_pt_on_segment is what ptarray_raycast_intersections reads to find a point
on the boundary of a ring, and it answers true for every point inside the
bounding box of the segment, so a point inside a ring and near one of its
edges reads as on the boundary. It tests the side of the segment the point
lies on first, and reads the point as on the segment only on the line of the
segment and between its ends.


Keep the box test of the distance walk off a part that has no box

Replicates PostGIS commit e5cc9ae7a1 of the stable-3.6 line, "Avoid possible
null pointer dereference" (PostGIS ticket 6000).

lw_dist2d_check_overlap computes the missing box of a part into the box
pointer of that part, the very pointer that is NULL. The test becomes static
to the distance walk, which gives each part its box before calling it, and
asserts that both boxes are there; its declaration leaves measures.h, from
which nothing else reads it. The walk also skips a part that a collection
holds as NULL.


Read a point equal to a vertex of a ring as on its boundary

Replicates PostGIS commit 80eefad13b of the stable-3.6 line, "Fix
robustness issue in ptarray_contains_point" (PostGIS ticket 6023), with its
unit test left out.

The winding number of ptarray_contains_point decides a point lying on a
vertex of the ring from the side tests of the two edges meeting there, which
rounding can tip either way. A point equal to a vertex lies on the boundary,
and the test answers so before it counts.


Build the nearest point of an axis-aligned segment the way its box is built

Replicates PostGIS commit e91db587b9 of the stable-3.6 line, "Clean up and
add another special case to lw_dist2d_pt_seg()".

lw_dist2d_pt_seg measures the distance from a point to the inside of a
segment without building the nearest point, and builds that point only to
record it. On a vertical or a horizontal segment the box of the segment is
built from its coordinates as they are, so the measured distance can come
out below the distance between the boxes of the two geometries. On such a
segment the nearest point is built and the distance is measured to it,
which keeps the distance at or above the box distance.


Refuse an empty point array in the partial winding test

Replicates PostGIS commit af79a7a0cb of the stable-3.6 line, "Remove
potential null dereference from ptarray_contains_point_partial()".

ptarray_contains_point_partial reads the first and the last point of the
array before any check, so a missing or empty array is read past its end.
The test reports the error first and, as its unclosed-ring error does,
returns LW_OUTSIDE right after it; both errors name the function.


Cross a circle along the line of a segment, not from its nearest end

Replicates PostGIS commit 265a9edd2b of the stable-3.6 line, "Fix
CurvePolygon distance issue" (PostGIS ticket 5989), with its unit test left
out.

lw_dist2d_seg_arc takes D, the point of the segment nearest the centre of
the arc, which stops at an end of the segment, and builds the two crossings
of the line and the circle as D -/+ dir sqrt(r^2 - |CD|^2). Those lie on the
circle only when D is the foot of the perpendicular on the line. With D at
an end they lie off it, lw_pt_in_arc, a side-of-chord test that holds only
for points of the circle, can read one of them as on the arc, and the kernel
answers 0 for a segment far from the arc: LINESTRING(-68.783742 -2.494091,
-60.061866 -9.05758) against CIRCULARSTRING(-44.366 20.140,-46.412 17.269,
-51.606 11.029), whose line meets the circle at t = -13.2 and t = 0.036 with
the foot at t = -6.6, reads 0 where the closed form reads 21.134. The
crossings are built from the foot on the line.


Test the curve distance on the cases PostGIS tests it with

The PostGIS fixes this branch replicates come with unit tests that the tree
does not carry, so meos/test/geo_test.c checks geom_distance2d on the same
pairs, each to the tolerance its test gives: a point outside a curve polygon
beside its arc, a point beside the arc of a compound-curve polygon at
projected coordinates and a multisurface of compound curves against a
polygon (all three PostGIS ticket 5989), an arc inside the circle of a
semicircle, and a closed circle against that semicircle. A sixth pair is a
segment whose line crosses the circle of an arc away from the arc, 21.134199125017
from it by closed form and by a stroke of the arc into a million points,
which the kernel reads 0 while it builds the crossings from the end of the
segment nearest the centre.

Each of the six reads otherwise on the vendored code this branch starts
from: 0 for the three ticket cases and the segment, 0.588 for the arc inside
the semicircle and 0.496 for the closed circle.

070_tgeo_spatialrels_tbl expects the eDwithin counts at distance 10 the
fixes give: 4803 rather than 4802 between tbl_geometry and tbl_tgeometry,
4296 rather than 4292 against tbl_tgeometry_seq and 9562 rather than 9563
against tbl_tgeometry_seqset. Seven pairs move, each a curve against a
temporal geometry, and a stroke of every value of each confirms the new
answer: g113 and g132 against t88 read 0 at one value where the stroke reads
21.134 and 13.079; g108 against t59 and t9, g140 against t82, and g144,
g140 and g156 against t88, t92 and t98 read 15.855, 18.884, 12.350, 36.574
and 12.288 where the stroke reads 4.796, 0.962 and 0 three times.


Draw the shortest line of a curve distance from the first geometry

The shortest line between two geometries starts on the first and ends on
the second, and the distance walk records it that way through dl->twisted,
which says whether the pair a kernel measures reads the two geometries in
their order or in the other. Four places in the curve kernels and the walk
record the point of the second geometry first, so the line comes out
reversed, and where two of them meet on one pair the line comes out right by
accident.

A curve polygon measures one of its rings against the other geometry with
lw_dist2d_recursive, in the order the two reach the curve polygon's own
function, and that walk sets dl->twisted afresh for each pair it measures,
losing the order of the pair being measured whenever it is the other.
lw_dist2d_recursive_oriented reads the ends in the other order on the way in
and on the way out in that case, and restores dl->twisted for the caller;
the 11 nested calls of the point, line, triangle and curve polygon functions
go through it.

lw_dist2d_pt_arc records the nearest end of the arc before the point in its
end-point branch and in the two cases where the point is the centre of the
circle; lw_dist2d_seg_arc measures the ends of the arc against the segment,
lw_dist2d_arc_arc measures a point-arc B against arc A and a straight arc B
against arc A, each with the second geometry first, without telling
dl->twisted, as lw_dist2d_seg_seg does; and lw_dist2d_arc_arc records a
point-arc pair with B first. Each records the point of the first geometry
first, the flips turning dl->twisted around the call and back.

meos/test/geo_test.c draws the line on eight pairs of curves the kernels
record reversed, one for each place above, and on three pairs in the order
they already record forward, and checks it runs from the first geometry to
the second on each.

Measured over the eight distance corpora against the vendored code this
branch starts from: no distance moves, the 30,000 random segment-arc pairs
answer bit for bit alike, and of the 11,935 shortest lines geo_pairs
answers, the 1,380 that start on the second geometry start on the first,
leaving none that runs the other way.


Measure every end of a segment and an arc the distance can stop at

lw_dist2d_seg_arc answers a segment and an arc that do not cross from flags
read on one point, a crossing of the line and the circle or the point of the
segment nearest the centre, and measures one family of end candidates: the
ends of the segment against the arc, the ends of the arc against the
segment, or the four pairs of ends. The flags do not rule the other families
out, so where the nearest pair belongs to another family the kernel answers
more than the distance, and the crossings built from the foot on the line
move which point the flags are read on.

The witness: LINESTRING(0 -100,0 100) against CIRCULARSTRING(40 60,20 52,
1 50) reads 50.01, where the end (1 50) of the arc lies at distance 1 from
the segment; meos/test/geo_test.c holds it beside the cases PostGIS tests.

The model: the closest points of a segment and an arc that neither cross
nor touch are an end of one against the other or, where the line misses the
circle, the point of the circle nearest the line against the foot of the
centre, when both lie on their pieces; the kernel answers that last pair
alone, as the least distance from the line to the circle bounds every pair.
After the family the flags choose, the four end candidates are measured as
well, each replacing the answer only where it is strictly nearer, so a tie
keeps the answer the flags give.

Measured: over 30,000 random segment and arc pairs judged by the closed
form, the kernel disagrees on 1,403 without this change and on none with
it; master disagrees on 1,856, 98 of them false zeros. In
070_tgeo_spatialrels_tbl the compound curve g132 moves from 10.159 to
9.6309 against the trips t85 and t10, which stroking the curve reads as
9.63086, so two eDwithin counts at distance 10 go from 4803 to 4804 and from
9562 to 9563. Callgrind counts the distance from 30 real multicurves to a
polygon at 20.12 million native instructions without this change and 24.03
million with it, the price of the end candidates, and 202 pairs of real
trips at 204.54 million both ways; the skips that follow bring the
multicurves to 15.94 million.

With the replays before it, the distance moves on 550 of the 12,880
geometry pairs of the regression data. Each is judged against both
geometries stroked into chords at 4,096 and 65,536 a quadrant, the gap
between the two densities bounding the stroking error, the chords measured
by a distance of two segment sets that is independent of both arc kernels
and matches the linear walk of liblwgeom to 3e-14 on the 113 rows both
measure. This change is right and master wrong on 111, both lie within the
bound on 439, and master is right on none.


Skip the parts of two geometries whose boxes lie further apart than the distance found

lw_dist2d_recursive measures every part of one geometry against every part
of the other: a multicurve of 897 arcs against a polygon is 897
measurements, each an arc against the rings of the polygon, however far the
arc lies from it. A box test decides which kernel measures a pair, but
nothing decides whether the pair needs measuring at all.

A pair of parts whose boxes lie further apart than the distance already
found is skipped. Every distance the walk computes between two parts is at
least the distance between their boxes, and the box of an arc is built to
enclose it, so such a pair cannot return a distance below the one found, up
to the rounding of the boxes and of the distance itself, which the margin of
16 eps (d + max|coord|) covers. The walk replaces its answer only with a
strictly smaller distance and still visits the pairs in their order, so
the distance and the pair of points it is read from are those of the full
walk. Nothing is skipped once the distance found is within the tolerance:
the walk then goes on to the pairs after the collection that found it, and
a pair crossing the other geometry, or starting inside it, writes its own
points there, so the pair measured next must be the one the full walk
measures. The test applies to the minimum distance only; for the maximum
distance a far pair is the one that decides.

The witness is the answer itself, bit for bit: geom_distance2d at 17 digits
and geom_shortestline2d as hex EWKB are identical to those of the walk
without the skip on the curved pairs, the arc subjects, the adversarial
pairs, the areal pairs, the trip pairs, the geometry pairs, the self pairs
and the natural-area pairs, 28,260 pairs in all.

Measured: with GEOS as a cost reference and never a witness, callgrind
counts the distance from 30 real multicurves, of up to 897 arcs, to a
polygon at 24.03 million native instructions without this change and 16.44
million with it, against 19.41 million on master, 47.40 million for GEOS as
MEOS calls it, which converts both operands, and 3.51 million for GEOS on
operands converted once, outside the count. On 202 pairs of real trips the
count stays at 204.54 and 204.56 million: a trip is a single line, so this
test has nothing to skip there.

Why: skipping a pair that cannot replace the answer changes what the walk
costs and never what it returns.


Skip the segments of two lines that lie further apart than the distance found

lw_dist2d_ptarray_ptarray measures every segment of one point array against
every segment of the other. Two trips whose boxes overlap reach it through
lw_dist2d_recursive, and a pair of 200-point trips is 40,000 segment
distances, most of them between segments nowhere near each other.

The walk skips a segment whose box lies further from the box of the other
point array than the distance found, and a pair of segments whose boxes lie
further apart than it, which are the two tests GEOS makes ahead of measuring
two segments. The test is the one lw_dist2d_recursive applies to parts, with
the same margin, the coordinates of both arrays bounding the rounding. The
segments are still visited in their order and the walk still replaces its
answer only with a strictly smaller distance, so the distance, and the pair
of points it is read from, are those of the full walk. As for the parts,
nothing is skipped once the distance found is within the tolerance, where
the walk ends after the next pair it measures. The last pair of segments is
always measured: the orientation lw_dist2d_seg_seg leaves in dl->twisted is
the one the next ring of a polygon starts from. The test applies to the
minimum distance only.

The witness is the answer itself, bit for bit: geom_distance2d at 17 digits
and geom_shortestline2d as hex EWKB are identical to those of the walk
without the skip on the same eight corpora, 28,260 pairs in all.

Measured: with GEOS as a cost reference and never a witness, callgrind
counts the distance between 202 pairs of real trips at 204.56 million native
instructions without this change and 29.16 million with it, against 166.30
million on master, 34.89 million for GEOS as MEOS calls it and 29.64 million
for GEOS on operands converted once, outside the count. The 30 multicurves
stay at 16.44 and 16.45 million, their arcs being measured by the arc
kernels rather than by this walk.


Skip a segment and an arc whose boxes lie further apart than the distance found

lw_dist2d_ptarray_ptarrayarc measures every segment of a line against every
arc of a circular string, however far apart the two lie, and each pair costs
the kernel the crossings of the line and the circle and the ends of each
piece against the other.

A segment whose box lies further from the box of the arcs, or from the box
of one arc, than the distance already found is skipped, as the segments of
two lines are, the box of an arc being built to enclose the arc it draws;
the box of each arc is built once, for every segment it is measured
against. The walk still visits the pairs in their order, skips nothing once
the distance is within the tolerance and always measures the last pair, so
it returns the distance and the pair of points of the walk that measures
every pair.

The witness is the answer itself, bit for bit: the eight distance corpora
answer the distance at 17 digits and the shortest line as hex EWKB exactly
as the walk without the skips, and the 30,000 random segment-arc pairs are
unchanged.

Measured: with GEOS as a cost reference and never a witness, callgrind
counts the distance from the 30 multicurves to a polygon at 16.45 million
native instructions without this change and 15.94 million with it, against
19.41 million on master, 47.40 million for GEOS as MEOS calls it and 3.51
million for GEOS on operands converted once, outside the count; the 202
pairs of trips, single lines, stay at 29.16 million. With the three skips,
the 20 largest pairs of natural-area polygons count 2,308.76 million native
instructions, against 94,427.9 million on master, 2,667.82 million for GEOS
as MEOS calls it and 2,558.35 million for GEOS alone.


