### PR TITLE
Measure a segment and an arc against an arc at every scale

### DIFF
--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -697,6 +697,41 @@ int main(void)
   assert(dist_ok == 41);
   meos_errno_reset();
 
+  /* A segment and an arc take their distance to an arc from its size in the
+   * same way. The segment from (0 2s) to (2s 2s) and the arc through (0 3s),
+   * (s 2s) and (2s 3s), whose centre is (s 3s) and whose lowest point is
+   * (s 2s), each lie at distance s from the semicircle, exactly: the nearest
+   * point of the semicircle is its top (s s). A circle read as its chord below
+   * an absolute bound on twice the area of the arc, 4s^2 against 1e-8 from
+   * s = 2^-16, puts them at 2s and 3s, and a whole circle read from ends
+   * closer than 1e-8, from s = 2^-28, at 0.79s and 0.59s */
+  double seg_s = 1.0;
+  int seg_ok = 0;
+  for (int k = 0; k >= -40; k--, seg_s *= 0.5)
+  {
+    char semi_wkt[160], seg_wkt[128], arc_wkt[160];
+    snprintf(semi_wkt, sizeof semi_wkt,
+      "CIRCULARSTRING(0 0,%.17g %.17g,%.17g 0)", seg_s, seg_s, 2 * seg_s);
+    snprintf(seg_wkt, sizeof seg_wkt, "LINESTRING(0 %.17g,%.17g %.17g)",
+      2 * seg_s, 2 * seg_s, 2 * seg_s);
+    snprintf(arc_wkt, sizeof arc_wkt,
+      "CIRCULARSTRING(0 %.17g,%.17g %.17g,%.17g %.17g)", 3 * seg_s, seg_s,
+      2 * seg_s, 2 * seg_s, 3 * seg_s);
+    GSERIALIZED *semi = geom_in(semi_wkt, -1);
+    GSERIALIZED *seg = geom_in(seg_wkt, -1);
+    GSERIALIZED *arc = geom_in(arc_wkt, -1);
+    assert(semi != NULL); assert(seg != NULL); assert(arc != NULL);
+    assert(geom_distance2d(semi, seg) == seg_s);
+    assert(geom_distance2d(seg, semi) == seg_s);
+    assert(geom_distance2d(semi, arc) == seg_s);
+    seg_ok++;
+    free(semi); free(seg); free(arc);
+  }
+  printf("the distance from a segment and from an arc to a semicircle is its "
+    "closed form at %d scales from 1 to 2^-40\n", seg_ok);
+  assert(seg_ok == 41);
+  meos_errno_reset();
+
   /* The distance between curves is checked on the cases PostGIS gives its
    * own unit tests for the distance fixes of its 3.6 line (ticket 5989): a
    * point outside a curve polygon beside its arc, a point beside the arc of a

--- a/postgis/liblwgeom/measures.c
+++ b/postgis/liblwgeom/measures.c
@@ -1510,6 +1510,48 @@ lw_dist2d_ptarrayarc_ptarrayarc(const POINTARRAY *pa, const POINTARRAY *pb, DIST
 	return LW_TRUE;
 }
 
+/* MEOS: the cross product of coordinate differences, computed exactly and
+ * rounded once, from meos/src/geo/geo_funcs.c */
+extern double cross_product_exact(double ax, double ay, double bx, double by,
+	double cx, double cy, double dx, double dy);
+
+/* MEOS: the circle of an arc as lw_arc_center computes it, decided on the
+ * input vertices as lw_dist2d_pt_arc decides it rather than against bounds of
+ * a fixed size. An arc whose ends are the same vertex is the whole circle on
+ * the diameter A1-A2. Three points whose turn, the cross product of A2 - A1
+ * and A3 - A1, is zero are collinear, A2 on an end included, and the arc is
+ * the segment A1-A3, for which the function returns -1. The rounded turn is
+ * nonzero, and of the sign of the exact one, where it exceeds the error bound
+ * of Shewchuk's orient2d filter, (3 + 16u) u (|left| + |right|) with u the
+ * unit roundoff; only below it is the turn computed exactly. Every term of
+ * the circumcentre, and the bound, scales with the arc, so the circle does
+ * too */
+static double
+lw_dist2d_arc_circle(const POINT2D *A1, const POINT2D *A2, const POINT2D *A3, POINT2D *C)
+{
+	double dx21 = A2->x - A1->x, dy21 = A2->y - A1->y;
+	if (A1->x == A3->x && A1->y == A3->y)
+	{
+		C->x = A1->x + dx21 / 2.0;
+		C->y = A1->y + dy21 / 2.0;
+		return sqrt((C->x - A1->x) * (C->x - A1->x) + (C->y - A1->y) * (C->y - A1->y));
+	}
+	double dx31 = A3->x - A1->x, dy31 = A3->y - A1->y;
+	double left = dx21 * dy31, right = dx31 * dy21;
+	double cross = left - right;
+	double u = DBL_EPSILON / 2.0;
+	if (! (fabs(cross) > (3.0 + 16.0 * u) * u * (fabs(left) + fabs(right))))
+		cross = cross_product_exact(A1->x, A1->y, A2->x, A2->y,
+			A1->x, A1->y, A3->x, A3->y);
+	if (cross == 0.0)
+		return -1.0;
+	double h21 = dx21 * dx21 + dy21 * dy21, h31 = dx31 * dx31 + dy31 * dy31;
+	double d = 2.0 * cross;
+	C->x = A1->x + (h21 * dy31 - h31 * dy21) / d;
+	C->y = A1->y - (h21 * dx31 - h31 * dx21) / d;
+	return sqrt((C->x - A1->x) * (C->x - A1->x) + (C->y - A1->y) * (C->y - A1->y));
+}
+
 /**
  * Calculate the shortest distance between an arc and an edge.
  * Line/circle approach from http://stackoverflow.com/questions/1073336/circle-line-collision-detection
@@ -1541,7 +1583,7 @@ lw_dist2d_seg_arc(const POINT2D *A1,
 		return lw_dist2d_pt_seg(B1, A1, A2, dl);
 
 	/* Calculate center and radius of the circle. */
-	radius_C = lw_arc_center(B1, B2, B3, &C);
+	radius_C = lw_dist2d_arc_circle(B1, B2, B3, &C); /* MEOS */
 
 	/* This "arc" is actually a line (B2 is collinear with B1,B3) */
 	if (radius_C < 0.0)
@@ -1861,7 +1903,8 @@ lw_dist2d_circle_intersections(
 
 	// If the test point is on the center of the other
 	// arc, some other point has to be closer, by definition.
-	if (p2d_same(center_A, P))
+	/* MEOS: exactly the centre, the one point with no direction to it */
+	if (center_A->x == P->x && center_A->y == P->y)
 		return 0;
 
 	// Calculate vector from the center to the pt
@@ -1947,8 +1990,10 @@ lw_dist2d_circle_circle_intersections(
 	I[0].x = Px - h * (dy / d);
 	I[0].y = Py + h * (dx / d);
 
-	// If h is very close to 0, the circles are tangent and there's only one intersection point.
-	if (FP_IS_ZERO(h))
+	/* MEOS: the circles are tangent, with one point in common, where h is 0;
+	 * a small h still gives two points, each on both circles to within
+	 * rounding */
+	if (h == 0.0)
 		return 1;
 
 	// Intersection point 2
@@ -1997,8 +2042,8 @@ lw_dist2d_arc_arc(
 		return lw_dist2d_pt_arc(A1, B1, B2, B3, dl);
 
 	/* Calculate centers and radii of circles. */
-	radius_A = lw_arc_center(A1, A2, A3, &center_A);
-	radius_B = lw_arc_center(B1, B2, B3, &center_B);
+	radius_A = lw_dist2d_arc_circle(A1, A2, A3, &center_A); /* MEOS */
+	radius_B = lw_dist2d_arc_circle(B1, B2, B3, &center_B); /* MEOS */
 
 	/* Two co-linear arcs?!? That's two segments. */
 	if (radius_A < 0 && radius_B < 0)
@@ -2024,7 +2069,9 @@ lw_dist2d_arc_arc(
 	d = distance2d_pt_pt(&center_A, &center_B);
 	is_disjoint = (d > (radius_A + radius_B));
 	is_contained = (d < fabs(radius_A - radius_B));
-	is_same_center = p2d_same(&center_A, &center_B);
+	/* MEOS: the same centre exactly, the one case with no line through the
+	 * two centres */
+	is_same_center = (center_A.x == center_B.x && center_A.y == center_B.y);
 	is_overlapping = ! (is_disjoint || is_contained || is_same_center);
 
 	/*


### PR DESCRIPTION
lw_dist2d_seg_arc and lw_dist2d_arc_arc take the circle of an arc from
lw_arc_center, which reads three points as collinear where twice the area
they span is below 1e-8, and an arc as a whole circle where its ends lie
within 1e-8 of each other. Both bounds are absolute, so the answer depends on
the size of the geometry: a semicircle of radius 2^-16 spans twice an area of
4 * 2^-32, below the first bound, and is measured as its chord, and one of
radius 2^-28 has its ends closer than the second and is measured as the
circle on the diameter from its first vertex to its middle one.

The circle keeps the circumcentre lw_arc_center computes, every term of
which scales with the arc, and decides its two cases on the input vertices as
lw_dist2d_pt_arc does. An arc whose ends are the same vertex is the whole
circle on the diameter from its first vertex to its middle one; three points
whose turn, the cross product of the vectors from the first vertex to the
other two, is zero are a segment. The rounded turn is nonzero, and of the
sign of the exact one, where it exceeds the error bound of Shewchuk's
orient2d filter, (3 + 16u) u times the sum of the magnitudes of its two
products, u the unit roundoff; only below that bound is the turn computed
exactly. The three tests the circle then feeds, whether two circles share
their centre, whether a point is the centre of a circle and whether two
circles touch at a single point, compare the values themselves rather than
to within 1e-12.

The witness: the segment from (0 2s) to (2s 2s) and the arc through (0 3s),
(s 2s) and (2s 3s) lie at distance s from the semicircle through (0 0),
(s s) and (2s 0), exactly. On master the segment reads 2s and the arc 3s
from s = 2^-16, and 0.79s and 0.59s from s = 2^-28; meos/test/geo_test.c
holds both at 41 scales from 1 to 2^-40, beside the point above the
semicircle, which reads s at all of them.

The rule: IEEE arithmetic commutes exactly with a power of two, so the
distance of a pair scaled by 2^k is the distance of the pair scaled by 2^k,
bit for bit, wherever nothing compares a value against a constant of fixed
size.

Measured: over 2,000 random segment-arc pairs and 2,000 random arc-arc
pairs, each scaled by 2^16, 2^8, 2^-8, 2^-16, 2^-24, 2^-32 and 2^-40, master
moves up to 1,166 and 1,793 distances at a scale, and this change none.
Every other answer is master's to the last bit: the 30,000 random
segment-arc pairs, which agree with the closed form, and the 28,260 pairs of
the eight distance corpora, distance and shortest line alike. With GEOS as a
cost reference and never a witness, callgrind counts the distance from 30
real multicurves to a polygon at 15.96 million native instructions against
15.94 million on master, the turn of a nearly collinear arc being computed
exactly, and 3.51 million for GEOS on operands converted once; 202 pairs of
real trips stay at 29.16 million and the 20 largest natural-area pairs at
2,308.76 million.

