### PR TITLE
Answer a spatial relationship the same at every scale

### DIFF
--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -61,17 +61,22 @@
 /**
  * @brief Add to the dynamic array in the last argument the edges obtained
  * from a ring
+ * @param[in] pa Ring
+ * @param[out] edges Edges
+ * @param[in] etype Type of the edges
+ * @param[in] scale Factor every coordinate is read at, a power of two
  */
 static void
-emit_ring_edges(const POINTARRAY *pa, MeosArray *edges, EdgeType etype)
+emit_ring_edges(const POINTARRAY *pa, MeosArray *edges, EdgeType etype,
+  double scale)
 {
   for (int i = 0; i < (int) pa->npoints - 1; i++)
   {
     const POINT2D *a = getPoint2d_cp(pa, i);
     const POINT2D *b = getPoint2d_cp(pa, i + 1);
     Edge e;
-    e.x1 = a->x; e.y1 = a->y;
-    e.x2 = b->x; e.y2 = b->y;
+    e.x1 = a->x * scale; e.y1 = a->y * scale;
+    e.x2 = b->x * scale; e.y2 = b->y * scale;
     e.xmin = Min(e.x1, e.x2); e.xmax = Max(e.x1, e.x2);
     e.ymin = Min(e.y1, e.y2); e.ymax = Max(e.y1, e.y2);
     e.dx = e.x2 - e.x1; e.dy = e.y2 - e.y1;
@@ -88,7 +93,7 @@ emit_ring_edges(const POINTARRAY *pa, MeosArray *edges, EdgeType etype)
  * from a point
  */
 static void
-extract_point(const LWPOINT *pt, MeosArray *edges)
+extract_point(const LWPOINT *pt, MeosArray *edges, double scale)
 {
   /* An empty point (e.g. a component of a multipoint or the boundary of a
    * closed trajectory) has no vertex to read; it contributes no edge. */
@@ -96,8 +101,8 @@ extract_point(const LWPOINT *pt, MeosArray *edges)
     return;
   const POINT2D *p = getPoint2d_cp(pt->point, 0);
   Edge e;
-  e.x1 = e.x2 = e.xmin = e.xmax = p->x;
-  e.y1 = e.y2 = e.ymin = e.ymax = p->y;
+  e.x1 = e.x2 = e.xmin = e.xmax = p->x * scale;
+  e.y1 = e.y2 = e.ymin = e.ymax = p->y * scale;
   e.dx = e.dy = e.length = 0;
   e.etype = EDGE_POINT;
   edge_set_tolerance(&e);
@@ -110,10 +115,10 @@ extract_point(const LWPOINT *pt, MeosArray *edges)
  * from a multipoint
  */
 static void
-extract_mpoint(const LWMPOINT *mp, MeosArray *edges)
+extract_mpoint(const LWMPOINT *mp, MeosArray *edges, double scale)
 {
   for (int i = 0; i < (int) mp->ngeoms; i++)
-    extract_point((const LWPOINT *) mp->geoms[i], edges);
+    extract_point((const LWPOINT *) mp->geoms[i], edges, scale);
   return;
 }
 
@@ -122,9 +127,9 @@ extract_mpoint(const LWMPOINT *mp, MeosArray *edges)
  * from a line
  */
 static void
-extract_line(const LWLINE *line, MeosArray *edges)
+extract_line(const LWLINE *line, MeosArray *edges, double scale)
 {
-  emit_ring_edges(line->points, edges, EDGE_LINESEG);
+  emit_ring_edges(line->points, edges, EDGE_LINESEG, scale);
   return;
 }
 
@@ -133,10 +138,10 @@ extract_line(const LWLINE *line, MeosArray *edges)
  * from a multiline
  */
 static void
-extract_mline(const LWMLINE *ml, MeosArray *edges)
+extract_mline(const LWMLINE *ml, MeosArray *edges, double scale)
 {
   for (int i = 0; i < (int) ml->ngeoms; i++)
-    extract_line(ml->geoms[i], edges);
+    extract_line(ml->geoms[i], edges, scale);
   return;
 }
 
@@ -151,9 +156,12 @@ extract_mline(const LWMLINE *ml, MeosArray *edges)
  * #ptarray_signed_area accumulates DIFFERENCES of coordinates rather than the
  * coordinates themselves, so its rounding grows with that extent and not with
  * the distance of the ring from the origin.
+ * @note The ring is read at @p scale, a power of two, which scales every
+ * difference of coordinates exactly: the extent by @p scale and the area by
+ * its square, as if both were computed from the scaled coordinates
  */
 static bool
-ring_encloses_no_area(const POINTARRAY *pa)
+ring_encloses_no_area(const POINTARRAY *pa, double scale)
 {
   if (! pa || pa->npoints < 3)
     return true;
@@ -166,10 +174,10 @@ ring_encloses_no_area(const POINTARRAY *pa)
     xmin = Min(xmin, p->x); xmax = Max(xmax, p->x);
     ymin = Min(ymin, p->y); ymax = Max(ymax, p->y);
   }
-  double extent = Max(xmax - xmin, ymax - ymin);
+  double extent = Max(xmax - xmin, ymax - ymin) * scale;
   double tol = (MEOS_GEOM_TOLERANCE +
     4.0 * DBL_EPSILON * (double) pa->npoints * extent) * extent;
-  return fabs(ptarray_signed_area(pa)) <= tol;
+  return fabs(ptarray_signed_area(pa)) * scale * scale <= tol;
 }
 
 /**
@@ -182,20 +190,20 @@ ring_encloses_no_area(const POINTARRAY *pa)
  * none: its linework already lies in that surface.
  */
 static void
-extract_poly(const LWPOLY *poly, MeosArray *edges)
+extract_poly(const LWPOLY *poly, MeosArray *edges, double scale)
 {
   if (poly->nrings == 0)
     return;
-  if (ring_encloses_no_area(poly->rings[0]))
+  if (ring_encloses_no_area(poly->rings[0], scale))
   {
-    emit_ring_edges(poly->rings[0], edges, EDGE_LINESEG);
+    emit_ring_edges(poly->rings[0], edges, EDGE_LINESEG, scale);
     return;
   }
   for (int r = 0; r < (int) poly->nrings; r++)
   {
-    if (r > 0 && ring_encloses_no_area(poly->rings[r]))
+    if (r > 0 && ring_encloses_no_area(poly->rings[r], scale))
       continue;
-    emit_ring_edges(poly->rings[r], edges, EDGE_POLYSEG);
+    emit_ring_edges(poly->rings[r], edges, EDGE_POLYSEG, scale);
   }
   return;
 }
@@ -205,10 +213,10 @@ extract_poly(const LWPOLY *poly, MeosArray *edges)
  * from a multipolygon
  */
 static void
-extract_mpoly(const LWMPOLY *mp, MeosArray *edges)
+extract_mpoly(const LWMPOLY *mp, MeosArray *edges, double scale)
 {
   for (int i = 0; i < (int) mp->ngeoms; i++)
-    extract_poly(mp->geoms[i], edges);
+    extract_poly(mp->geoms[i], edges, scale);
   return;
 }
 
@@ -219,10 +227,11 @@ extract_mpoly(const LWMPOLY *mp, MeosArray *edges)
  * POINTARRAY, which is already closed or implicitly closed
  */
 static void
-extract_triangle(const LWTRIANGLE *tri, MeosArray *edges)
+extract_triangle(const LWTRIANGLE *tri, MeosArray *edges, double scale)
 {
   emit_ring_edges(tri->points, edges,
-    ring_encloses_no_area(tri->points) ? EDGE_LINESEG : EDGE_POLYSEG);
+    ring_encloses_no_area(tri->points, scale) ? EDGE_LINESEG : EDGE_POLYSEG,
+    scale);
   return;
 }
 
@@ -346,18 +355,25 @@ emit_arc_edge(const POINT2D *pa, const POINT2D *pb, const POINT2D *pc,
  * @p line_etype and genuine arcs with @p arc_etype. A standalone circular
  * string uses the 1D types (#EDGE_LINESEG / #EDGE_LINEARC); a circular string that
  * bounds a curve polygon ring uses the region types (#EDGE_POLYSEG /
- * #EDGE_POLYARC)
+ * #EDGE_POLYARC). The three points of an arc reach #emit_arc_edge already
+ * scaled, so that whether it reads them as a chord or as a whole circle is
+ * decided at the size the edge is built at
  */
 static void
 emit_circstring_edges(const LWCIRCSTRING *circ, MeosArray *edges,
-  EdgeType line_etype, EdgeType arc_etype)
+  EdgeType line_etype, EdgeType arc_etype, double scale)
 {
   const POINTARRAY *pa = circ->points;
   int np = (int) pa->npoints;
   for (int i = 0; i + 2 < np; i += 2)
   {
-    emit_arc_edge(getPoint2d_cp(pa, i), getPoint2d_cp(pa, i + 1),
-      getPoint2d_cp(pa, i + 2), edges, line_etype, arc_etype);
+    POINT2D p[3];
+    for (int j = 0; j < 3; j++)
+    {
+      const POINT2D *q = getPoint2d_cp(pa, i + j);
+      p[j].x = q->x * scale; p[j].y = q->y * scale;
+    }
+    emit_arc_edge(&p[0], &p[1], &p[2], edges, line_etype, arc_etype);
   }
   return;
 }
@@ -367,9 +383,9 @@ emit_circstring_edges(const LWCIRCSTRING *circ, MeosArray *edges,
  * from a circular string
  */
 static void
-extract_circstring(const LWCIRCSTRING *circ, MeosArray *edges)
+extract_circstring(const LWCIRCSTRING *circ, MeosArray *edges, double scale)
 {
-  emit_circstring_edges(circ, edges, EDGE_LINESEG, EDGE_LINEARC);
+  emit_circstring_edges(circ, edges, EDGE_LINESEG, EDGE_LINEARC, scale);
   return;
 }
 
@@ -382,17 +398,18 @@ extract_circstring(const LWCIRCSTRING *circ, MeosArray *edges)
  * #point_in_polygon treats it as a boundary rather than a 1D feature
  */
 static void
-extract_curvepoly_ring(const LWGEOM *ring, MeosArray *edges)
+extract_curvepoly_ring(const LWGEOM *ring, MeosArray *edges, double scale)
 {
   switch (ring->type)
   {
     case LINETYPE:
-      emit_ring_edges(((const LWLINE *) ring)->points, edges, EDGE_POLYSEG);
+      emit_ring_edges(((const LWLINE *) ring)->points, edges, EDGE_POLYSEG,
+        scale);
       break;
 
     case CIRCSTRINGTYPE:
       emit_circstring_edges((const LWCIRCSTRING *) ring, edges, EDGE_POLYSEG,
-        EDGE_POLYARC);
+        EDGE_POLYARC, scale);
       break;
 
     /* A compound curve is a chain of line strings and circular strings; it
@@ -402,7 +419,7 @@ extract_curvepoly_ring(const LWGEOM *ring, MeosArray *edges)
     {
       const LWCOLLECTION *col = (const LWCOLLECTION *) ring;
       for (int i = 0; i < (int) col->ngeoms; i++)
-        extract_curvepoly_ring(col->geoms[i], edges);
+        extract_curvepoly_ring(col->geoms[i], edges, scale);
       break;
     }
 
@@ -420,10 +437,10 @@ extract_curvepoly_ring(const LWGEOM *ring, MeosArray *edges)
  * from a curve polygon
  */
 static void
-extract_curvepoly(const LWCURVEPOLY *cp, MeosArray *edges)
+extract_curvepoly(const LWCURVEPOLY *cp, MeosArray *edges, double scale)
 {
   for (int r = 0; r < (int) cp->nrings; r++)
-    extract_curvepoly_ring(cp->rings[r], edges);
+    extract_curvepoly_ring(cp->rings[r], edges, scale);
   return;
 }
 
@@ -431,7 +448,7 @@ extract_curvepoly(const LWCURVEPOLY *cp, MeosArray *edges)
  * @brief Return the edges of a geometry in a dynamic array (iterator)
  */
 static void
-geom_extract_edges_iter(const LWGEOM *geom, MeosArray *edges)
+geom_extract_edges_iter(const LWGEOM *geom, MeosArray *edges, double scale)
 {
   /* Skip empty (sub-)geometries: an empty component contributes no edges, and
    * extracting one would read vertex 0 of an empty point array. This covers
@@ -442,31 +459,31 @@ geom_extract_edges_iter(const LWGEOM *geom, MeosArray *edges)
   switch (geom->type)
   {
     case POINTTYPE:
-      extract_point((const LWPOINT *) geom, edges);
+      extract_point((const LWPOINT *) geom, edges, scale);
       break;
 
     case MULTIPOINTTYPE:
-      extract_mpoint((const LWMPOINT *) geom, edges);
+      extract_mpoint((const LWMPOINT *) geom, edges, scale);
       break;
 
     case LINETYPE:
-      extract_line((const LWLINE *) geom, edges);
+      extract_line((const LWLINE *) geom, edges, scale);
       break;
 
     case MULTILINETYPE:
-      extract_mline((const LWMLINE *) geom, edges);
+      extract_mline((const LWMLINE *) geom, edges, scale);
       break;
 
     case POLYGONTYPE:
-      extract_poly((const LWPOLY *) geom, edges);
+      extract_poly((const LWPOLY *) geom, edges, scale);
       break;
 
     case MULTIPOLYGONTYPE:
-      extract_mpoly((const LWMPOLY *) geom, edges);
+      extract_mpoly((const LWMPOLY *) geom, edges, scale);
       break;
 
     case TRIANGLETYPE:
-      extract_triangle((const LWTRIANGLE *) geom, edges);
+      extract_triangle((const LWTRIANGLE *) geom, edges, scale);
       break;
 
     /* A compound curve (chain of line/circular strings), a multicurve
@@ -484,16 +501,16 @@ geom_extract_edges_iter(const LWGEOM *geom, MeosArray *edges)
     {
       const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
       for (int i = 0; i < (int) col->ngeoms; i++)
-        geom_extract_edges_iter(col->geoms[i], edges);
+        geom_extract_edges_iter(col->geoms[i], edges, scale);
       break;
     }
 
     case CIRCSTRINGTYPE:
-      extract_circstring((const LWCIRCSTRING *) geom, edges);
+      extract_circstring((const LWCIRCSTRING *) geom, edges, scale);
       break;
 
     case CURVEPOLYTYPE:
-      extract_curvepoly((const LWCURVEPOLY *) geom, edges);
+      extract_curvepoly((const LWCURVEPOLY *) geom, edges, scale);
       break;
 
     /* Unsupported type */
@@ -506,14 +523,28 @@ geom_extract_edges_iter(const LWGEOM *geom, MeosArray *edges)
 }
 
 /**
- * @brief Return the edges of a geometry in a dynamic array 
+ * @brief Return the edges of a geometry read at a scale, in a dynamic array
+ * @details Every coordinate is multiplied by @p scale as it is read, so the
+ * edges are those of the scaled geometry, built without copying it. A power
+ * of two scales every coordinate exactly
+ * @param[in] geom Geometry
+ * @param[in] scale Factor every coordinate is read at, a power of two
+ */
+static MeosArray *
+geom_extract_edges_scaled(const LWGEOM *geom, double scale)
+{
+  MeosArray *edges = meos_array_create(sizeof(Edge));
+  geom_extract_edges_iter(geom, edges, scale);
+  return edges;
+}
+
+/**
+ * @brief Return the edges of a geometry in a dynamic array
  */
 MeosArray *
 geom_extract_edges(const LWGEOM *geom)
 {
-  MeosArray *edges = meos_array_create(sizeof(Edge));
-  geom_extract_edges_iter(geom, edges);
-  return edges;
+  return geom_extract_edges_scaled(geom, 1.0);
 }
 
 /**
@@ -3892,7 +3923,7 @@ de9im_init(MeosDE9IM *m)
 
 static POINT2D *relate_linear_boundary_points(Edge **edges, int nedges,
   int *count);
-static MeosArray *relate_extract_edges(const LWGEOM *geom);
+static MeosArray *relate_extract_edges(const LWGEOM *geom, double scale);
 static bool relate_area_boundary_edge(const Edge *e);
 static void relate_area_edge_point(const Edge *e, double t, double *x,
   double *y);
@@ -3919,23 +3950,29 @@ typedef struct
  * geometries, and reading the edges of a multi-surface as those of the union
  * of its members is what a call on such a geometry mostly costs. The two
  * operands are therefore extracted ONCE where the relationship begins, and
- * each step borrows the edges from here rather than extracting them again
+ * each step borrows the edges from here rather than extracting them again.
+ * Every coordinate the relationship reads is read at one scale, which
+ * #relate_scale_factor sets from the two operands together
  */
 typedef struct
 {
   RelateOperand op[2];  /**< The two operands, in the order asked about */
+  double scale;         /**< Factor every coordinate is read at */
 } RelateOperands;
 
 /**
- * @brief Extract the edges of both operands of a relationship
+ * @brief Extract the edges of both operands of a relationship, reading every
+ * coordinate at a scale
  */
 static void
-relate_operands_init(RelateOperands *ops, const LWGEOM *g1, const LWGEOM *g2)
+relate_operands_init(RelateOperands *ops, const LWGEOM *g1, const LWGEOM *g2,
+  double scale)
 {
+  ops->scale = scale;
   ops->op[0].geom = g1;
-  ops->op[0].arr = relate_extract_edges(g1);
+  ops->op[0].arr = relate_extract_edges(g1, scale);
   ops->op[1].geom = g2;
-  ops->op[1].arr = relate_extract_edges(g2);
+  ops->op[1].arr = relate_extract_edges(g2, scale);
   return;
 }
 
@@ -3953,8 +3990,9 @@ relate_operands_free(RelateOperands *ops)
 /**
  * @brief Return the edges of a geometry, reading the ones a relationship has
  * already extracted where the geometry is one of its two operands
- * @param[in] ops Operands of the relationship, NULL where the caller stands
- * outside one, in which case the edges are extracted as before
+ * @param[in] ops Operands of the relationship. An operand carrying no edges,
+ * as where the matrix is asked for on its own, and a geometry that is not an
+ * operand have their edges extracted here, at the scale of the relationship
  * @param[in] geom Geometry
  * @return The edges, which the caller gives back with #relate_return_edges
  * rather than releasing itself
@@ -3962,11 +4000,10 @@ relate_operands_free(RelateOperands *ops)
 static MeosArray *
 relate_borrow_edges(const RelateOperands *ops, const LWGEOM *geom)
 {
-  if (ops)
-    for (int i = 0; i < 2; i++)
-      if (ops->op[i].geom == geom)
-        return ops->op[i].arr;
-  return relate_extract_edges(geom);
+  for (int i = 0; i < 2; i++)
+    if (ops->op[i].geom == geom && ops->op[i].arr)
+      return ops->op[i].arr;
+  return relate_extract_edges(geom, ops->scale);
 }
 
 /**
@@ -3977,10 +4014,9 @@ relate_borrow_edges(const RelateOperands *ops, const LWGEOM *geom)
 static void
 relate_return_edges(const RelateOperands *ops, MeosArray *arr)
 {
-  if (ops)
-    for (int i = 0; i < 2; i++)
-      if (ops->op[i].arr == arr)
-        return;
+  for (int i = 0; i < 2; i++)
+    if (ops->op[i].arr == arr)
+      return;
   meos_array_destroy(arr);
   return;
 }
@@ -4335,13 +4371,16 @@ relate_count_points(const LWGEOM *geom)
  * @brief Append the points of a point geometry to an array
  */
 static void
-relate_extract_points_iter(const LWGEOM *geom, POINT2D *result, int *count)
+relate_extract_points_iter(const LWGEOM *geom, POINT2D *result, int *count,
+  double scale)
 {
   if (! geom || lwgeom_is_empty(geom))
     return;
   if (geom->type == POINTTYPE)
   {
-    result[*count] = *getPoint2d_cp(((const LWPOINT *) geom)->point, 0);
+    const POINT2D *p = getPoint2d_cp(((const LWPOINT *) geom)->point, 0);
+    result[*count].x = p->x * scale;
+    result[*count].y = p->y * scale;
     (*count)++;
     return;
   }
@@ -4349,7 +4388,7 @@ relate_extract_points_iter(const LWGEOM *geom, POINT2D *result, int *count)
     return;
   const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
   for (uint32_t i = 0; i < col->ngeoms; i++)
-    relate_extract_points_iter(col->geoms[i], result, count);
+    relate_extract_points_iter(col->geoms[i], result, count, scale);
   return;
 }
 
@@ -4359,14 +4398,16 @@ relate_extract_points_iter(const LWGEOM *geom, POINT2D *result, int *count)
  * one of them holding a single element, so both are related by the same code
  * @param[in] geom Point geometry
  * @param[out] count Number of points, zero for an empty geometry
+ * @param[in] scale Factor every coordinate is read at, the one the edges the
+ * points are located against are read at
  */
 static POINT2D *
-relate_extract_points(const LWGEOM *geom, int *count)
+relate_extract_points(const LWGEOM *geom, int *count, double scale)
 {
   POINT2D *result = palloc(sizeof(POINT2D) *
     (size_t) (relate_count_points(geom) + 1));
   *count = 0;
-  relate_extract_points_iter(geom, result, count);
+  relate_extract_points_iter(geom, result, count, scale);
   return result;
 }
 
@@ -4393,11 +4434,12 @@ relate_point_in_points(double x, double y, const POINT2D *points, int count)
  * compared element by element
  */
 static void
-relate_point_point(const LWGEOM *g1, const LWGEOM *g2, MeosDE9IM *m)
+relate_point_point(const LWGEOM *g1, const LWGEOM *g2, double scale,
+  MeosDE9IM *m)
 {
   int n1, n2;
-  POINT2D *p1 = relate_extract_points(g1, &n1);
-  POINT2D *p2 = relate_extract_points(g2, &n2);
+  POINT2D *p1 = relate_extract_points(g1, &n1, scale);
+  POINT2D *p2 = relate_extract_points(g2, &n2, scale);
 
   for (int i = 0; i < n1; i++)
   {
@@ -4425,7 +4467,7 @@ relate_point_linear(const LWGEOM *point_geom, const LWGEOM *line_geom,
   const RelateOperands *ops, MeosDE9IM *m)
 {
   int np;
-  POINT2D *points = relate_extract_points(point_geom, &np);
+  POINT2D *points = relate_extract_points(point_geom, &np, ops->scale);
   MeosArray *arr = relate_borrow_edges(ops, line_geom);
   int nedges = (int) arr->count;
   Edge **edges = palloc(sizeof(Edge *) * (size_t) (nedges + 1));
@@ -4481,7 +4523,7 @@ relate_point_area(const LWGEOM *point_geom, const LWGEOM *area_geom,
   const RelateOperands *ops, MeosDE9IM *m)
 {
   int np;
-  POINT2D *points = relate_extract_points(point_geom, &np);
+  POINT2D *points = relate_extract_points(point_geom, &np, ops->scale);
   MeosArray *arr = relate_borrow_edges(ops, area_geom);
   int nedges = (int) arr->count;
   Edge **edges = palloc(sizeof(Edge *) * (size_t) (nedges + 1));
@@ -6640,7 +6682,7 @@ typedef struct
  */
 static void
 relate_area_comps_iter(const LWGEOM *geom, RelateComp **comps, int *ncomp,
-  int *maxcomp, bool index)
+  int *maxcomp, bool index, double scale)
 {
   if (! geom || lwgeom_is_empty(geom))
     return;
@@ -6654,7 +6696,8 @@ relate_area_comps_iter(const LWGEOM *geom, RelateComp **comps, int *ncomp,
     {
       const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
       for (uint32_t i = 0; i < col->ngeoms; i++)
-        relate_area_comps_iter(col->geoms[i], comps, ncomp, maxcomp, index);
+        relate_area_comps_iter(col->geoms[i], comps, ncomp, maxcomp, index,
+          scale);
       return;
     }
     case POLYGONTYPE:
@@ -6670,7 +6713,7 @@ relate_area_comps_iter(const LWGEOM *geom, RelateComp **comps, int *ncomp,
     *comps = repalloc(*comps, sizeof(RelateComp) * (*maxcomp));
   }
   RelateComp *c = &(*comps)[(*ncomp)++];
-  c->arr = geom_extract_edges(geom);
+  c->arr = geom_extract_edges_scaled(geom, scale);
   c->nedges = (int) c->arr->count;
   c->edges = palloc(sizeof(Edge *) * Max(c->nedges, 1));
   for (int i = 0; i < c->nedges; i++)
@@ -6937,9 +6980,9 @@ relate_same_portion(const Edge *a, const Edge *b)
  * a multi-geometry
  */
 static MeosArray *
-relate_union_edges(const LWGEOM *geom)
+relate_union_edges(const LWGEOM *geom, double scale)
 {
-  MeosArray *all = geom_extract_edges(geom);
+  MeosArray *all = geom_extract_edges_scaled(geom, scale);
   int nall = (int) all->count;
   /* Every edge is located against every component, so a component is read
    * once for each edge and the two indexes below are worth what the same
@@ -6948,7 +6991,7 @@ relate_union_edges(const LWGEOM *geom)
 
   int ncomp = 0, maxcomp = 8;
   RelateComp *comps = palloc(sizeof(RelateComp) * maxcomp);
-  relate_area_comps_iter(geom, &comps, &ncomp, &maxcomp, index);
+  relate_area_comps_iter(geom, &comps, &ncomp, &maxcomp, index, scale);
 
   /* A collection holding at most one surface has no overlap to resolve */
   if (ncomp < 2)
@@ -7075,9 +7118,11 @@ relate_union_edges(const LWGEOM *geom)
  * multipolygon may share a boundary edge -- edge-adjacent polygons are a valid
  * multipolygon -- and that edge lies in the interior of what they cover
  * together, so reading the members' own edges reports it as boundary
+ * @param[in] geom Geometry
+ * @param[in] scale Factor every coordinate is read at, a power of two
  */
 static MeosArray *
-relate_extract_edges(const LWGEOM *geom)
+relate_extract_edges(const LWGEOM *geom, double scale)
 {
   switch (geom->type)
   {
@@ -7086,9 +7131,9 @@ relate_extract_edges(const LWGEOM *geom)
     case TINTYPE:
     case POLYHEDRALSURFACETYPE:
     case COLLECTIONTYPE:
-      return relate_union_edges(geom);
+      return relate_union_edges(geom, scale);
     default:
-      return geom_extract_edges(geom);
+      return geom_extract_edges_scaled(geom, scale);
   }
 }
 
@@ -7104,9 +7149,12 @@ relate_extract_edges(const LWGEOM *geom)
  * each dimension with a separate predicate cannot distinguish such a
  * collection from a homogeneous one, and routes it to whichever predicate is
  * tried first
+ * @param[in] geom Geometry
+ * @param[in] scale Factor every coordinate is read at, the one its edges are
+ * read at, so that a ring the edges read as enclosing no area is read so here
  */
 static int
-relate_dim_mask(const LWGEOM *geom)
+relate_dim_mask(const LWGEOM *geom, double scale)
 {
   if (! geom || lwgeom_is_empty(geom))
     return 0;
@@ -7124,10 +7172,11 @@ relate_dim_mask(const LWGEOM *geom)
     case POLYGONTYPE:
       /* A ring enclosing no area bounds no region, so what the surface draws
        * is its own linework and the dimension follows what it draws */
-      return ring_encloses_no_area(((const LWPOLY *) geom)->rings[0]) ? 2 : 4;
+      return ring_encloses_no_area(((const LWPOLY *) geom)->rings[0],
+        scale) ? 2 : 4;
     case TRIANGLETYPE:
-      return ring_encloses_no_area(((const LWTRIANGLE *) geom)->points) ?
-        2 : 4;
+      return ring_encloses_no_area(((const LWTRIANGLE *) geom)->points,
+        scale) ? 2 : 4;
     case CURVEPOLYTYPE:
     case MULTISURFACETYPE:
       return 4;
@@ -7145,7 +7194,7 @@ relate_dim_mask(const LWGEOM *geom)
       const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
       int mask = 0;
       for (uint32_t i = 0; i < col->ngeoms; i++)
-        mask |= relate_dim_mask(col->geoms[i]);
+        mask |= relate_dim_mask(col->geoms[i], scale);
       return (mask & 4) ? 4 : mask;
     }
     case COLLECTIONTYPE:
@@ -7153,7 +7202,7 @@ relate_dim_mask(const LWGEOM *geom)
       const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
       int mask = 0;
       for (uint32_t i = 0; i < col->ngeoms; i++)
-        mask |= relate_dim_mask(col->geoms[i]);
+        mask |= relate_dim_mask(col->geoms[i], scale);
       return mask;
     }
     default:
@@ -7170,13 +7219,13 @@ relate_dim_mask(const LWGEOM *geom)
  * @return The dimension, or -1 when the boundary is empty
  */
 static int8_t
-relate_boundary_dimension(const LWGEOM *geom)
+relate_boundary_dimension(const LWGEOM *geom, double scale)
 {
   if (relate_is_areal(geom))
     return 1;
   if (! relate_is_linear(geom))
     return -1;
-  MeosArray *arr = relate_extract_edges(geom);
+  MeosArray *arr = relate_extract_edges(geom, scale);
   int nedges = (int) arr->count;
   Edge **edges = palloc(sizeof(Edge *) * (size_t) (nedges + 1));
   for (int i = 0; i < nedges; i++)
@@ -7195,7 +7244,8 @@ relate_boundary_dimension(const LWGEOM *geom)
  * @brief Collect the components of a geometry having a given dimension
  */
 static void
-relate_stratum_iter(const LWGEOM *geom, int dim, LWGEOM **comps, int *ncomp)
+relate_stratum_iter(const LWGEOM *geom, int dim, LWGEOM **comps, int *ncomp,
+  double scale)
 {
   if (! geom || lwgeom_is_empty(geom))
     return;
@@ -7203,10 +7253,10 @@ relate_stratum_iter(const LWGEOM *geom, int dim, LWGEOM **comps, int *ncomp)
   {
     const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
     for (uint32_t i = 0; i < col->ngeoms; i++)
-      relate_stratum_iter(col->geoms[i], dim, comps, ncomp);
+      relate_stratum_iter(col->geoms[i], dim, comps, ncomp, scale);
     return;
   }
-  if (relate_dim_mask(geom) == (1 << dim))
+  if (relate_dim_mask(geom, scale) == (1 << dim))
     comps[(*ncomp)++] = (LWGEOM *) geom;
   return;
 }
@@ -7265,9 +7315,9 @@ relate_any_edge_intersection(const Edge *a, const Edge *b, double ix[2],
  */
 static bool
 relate_comp_covered(const LWGEOM *comp, const RelateComp *comps, int ncomp,
-  Edge **ledges, int nledges)
+  Edge **ledges, int nledges, double scale)
 {
-  MeosArray *arr = geom_extract_edges(comp);
+  MeosArray *arr = geom_extract_edges_scaled(comp, scale);
   int n = (int) arr->count;
   bool result = (n > 0);
   for (int i = 0; i < n && result; i++)
@@ -7322,11 +7372,11 @@ relate_comp_covered(const LWGEOM *comp, const RelateComp *comps, int ncomp,
  */
 static LWGEOM *
 relate_stratum(const LWGEOM *geom, int dim, int ncomps, const LWGEOM *area,
-  const LWGEOM *line)
+  const LWGEOM *line, double scale)
 {
   LWGEOM **comps = palloc(sizeof(LWGEOM *) * ncomps);
   int ncomp = 0;
-  relate_stratum_iter(geom, dim, comps, &ncomp);
+  relate_stratum_iter(geom, dim, comps, &ncomp, scale);
 
   /* Leave out every component a stratum of a larger dimension already
    * answers for */
@@ -7335,15 +7385,16 @@ relate_stratum(const LWGEOM *geom, int dim, int ncomps, const LWGEOM *area,
     int nareal = 0, maxareal = 8;
     RelateComp *areal = palloc(sizeof(RelateComp) * maxareal);
     if (area)
-      relate_area_comps_iter(area, &areal, &nareal, &maxareal, false);
-    MeosArray *larr = line ? geom_extract_edges(line) : NULL;
+      relate_area_comps_iter(area, &areal, &nareal, &maxareal, false, scale);
+    MeosArray *larr = line ? geom_extract_edges_scaled(line, scale) : NULL;
     int nledges = larr ? (int) larr->count : 0;
     Edge **ledges = palloc(sizeof(Edge *) * Max(nledges, 1));
     for (int i = 0; i < nledges; i++)
       ledges[i] = (Edge *) meos_array_get(larr, i);
     int nkept = 0;
     for (int i = 0; i < ncomp; i++)
-      if (! relate_comp_covered(comps[i], areal, nareal, ledges, nledges))
+      if (! relate_comp_covered(comps[i], areal, nareal, ledges, nledges,
+          scale))
         comps[nkept++] = comps[i];
     ncomp = nkept;
     pfree(ledges);
@@ -7416,7 +7467,7 @@ relate_simple(const LWGEOM *g1, const LWGEOM *g2, int mask1, int mask2,
   const RelateOperands *ops, MeosDE9IM *m)
 {
   if (mask1 == 1 && mask2 == 1)
-    relate_point_point(g1, g2, m);
+    relate_point_point(g1, g2, ops->scale, m);
   else if (mask1 == 1 && mask2 == 2)
     relate_point_linear(g1, g2, ops, m);
   else if (mask1 == 2 && mask2 == 1)
@@ -7467,10 +7518,10 @@ relate_dispatch(const LWGEOM *g1, const LWGEOM *g2, int mask1, int mask2,
    * larger ones already answer for */
   for (int j = 2; j >= 0; j--)
   {
-    s1[j] = (mask1 & (1 << j)) ?
-      relate_stratum(g1, j, ncomp1, s1[2], j == 0 ? s1[1] : NULL) : NULL;
-    s2[j] = (mask2 & (1 << j)) ?
-      relate_stratum(g2, j, ncomp2, s2[2], j == 0 ? s2[1] : NULL) : NULL;
+    s1[j] = (mask1 & (1 << j)) ? relate_stratum(g1, j, ncomp1, s1[2],
+      j == 0 ? s1[1] : NULL, ops->scale) : NULL;
+    s2[j] = (mask2 & (1 << j)) ? relate_stratum(g2, j, ncomp2, s2[2],
+      j == 0 ? s2[1] : NULL, ops->scale) : NULL;
   }
   /* Leaving a stratum out may leave a single dimension on a side */
   mask1 = (s1[0] ? 1 : 0) | (s1[1] ? 2 : 0) | (s1[2] ? 4 : 0);
@@ -7550,8 +7601,9 @@ relate_dispatch(const LWGEOM *g1, const LWGEOM *g2, int mask1, int mask2,
  * @brief Compute the DE-9IM intersection matrix, reading the edges a
  * relationship has already extracted where it has any
  * @param[in] g1,g2 Geometries
- * @param[in] ops Operands of the relationship the matrix answers a step of,
- * NULL where the matrix is asked for on its own
+ * @param[in] ops Operands of the relationship, carrying the scale every
+ * coordinate is read at and, where the matrix answers a step of a
+ * relationship, the edges it has already extracted
  * @param[out] result The matrix
  * @return true if the geometry pair is supported, which is what
  * #geom_meos_coverage answers 1 for each geometry
@@ -7580,24 +7632,69 @@ relate_matrix(const LWGEOM *g1, const LWGEOM *g2, const RelateOperands *ops,
     if (! empty2)
     {
       de9im_add(&m.ei, (int8_t) relate_dimension(g2));
-      de9im_add(&m.eb, relate_boundary_dimension(g2));
+      de9im_add(&m.eb, relate_boundary_dimension(g2, ops->scale));
     }
     if (! empty1)
     {
       de9im_add(&m.ie, (int8_t) relate_dimension(g1));
-      de9im_add(&m.be, relate_boundary_dimension(g1));
+      de9im_add(&m.be, relate_boundary_dimension(g1, ops->scale));
     }
     de9im_add(&m.ee, 2);
     de9im_to_string(&m, result);
     return true;
   }
 
-  int mask1 = relate_dim_mask(g1);
-  int mask2 = relate_dim_mask(g2);
+  int mask1 = relate_dim_mask(g1, ops->scale);
+  int mask2 = relate_dim_mask(g2, ops->scale);
   relate_dispatch(g1, g2, mask1, mask2, ops, &m);
 
   de9im_to_string(&m, result);
   return true;
+}
+
+/**
+ * @brief Return the scale a relationship reads the coordinates of two
+ * geometries at: the power of two bringing a joint extent below 1 into
+ * [1, 2), and 1 otherwise
+ * @details The relationship of two geometries does not change when both are
+ * scaled by the same factor, and a power of two scales every coordinate
+ * exactly, so the engine reading both at the scale answers as it would on the
+ * originals. The engine compares against bounds of a fixed size, which decide
+ * the shape of the edges it reads once the geometries are small against them:
+ * a curve and its buffer of radius 2^-20 read as meeting outside the buffer.
+ * Geometries spanning a unit or more are read as they are
+ * @return 1 where either geometry is geodetic or empty, where the joint
+ * extent is zero or a unit or more, or where a scaled coordinate would not be
+ * finite
+ */
+static double
+relate_scale_factor(const LWGEOM *g1, const LWGEOM *g2)
+{
+  /* A geodetic box is geocentric and says nothing of the coordinates */
+  if (FLAGS_GET_GEODETIC(g1->flags) || FLAGS_GET_GEODETIC(g2->flags) ||
+      lwgeom_is_empty(g1) || lwgeom_is_empty(g2))
+    return 1.0;
+  /* The box a geometry caches, or else one computed here and not kept, so
+   * that neither geometry is written to. The two are joined on the plane
+   * whatever dimensions each carries */
+  GBOX c1, c2;
+  if (g1->bbox)
+    c1 = *g1->bbox;
+  else if (lwgeom_calculate_gbox(g1, &c1) != LW_SUCCESS)
+    return 1.0;
+  if (g2->bbox)
+    c2 = *g2->bbox;
+  else if (lwgeom_calculate_gbox(g2, &c2) != LW_SUCCESS)
+    return 1.0;
+  double xmin = Min(c1.xmin, c2.xmin), xmax = Max(c1.xmax, c2.xmax);
+  double ymin = Min(c1.ymin, c2.ymin), ymax = Max(c1.ymax, c2.ymax);
+  double ext = Max(xmax - xmin, ymax - ymin);
+  if (! (ext > 0.0 && ext < 1.0))
+    return 1.0;
+  double f = scalbn(1.0, - ilogb(ext));
+  double reach = Max(Max(fabs(xmin), fabs(xmax)), Max(fabs(ymin),
+    fabs(ymax)));
+  return isfinite(reach * f) ? f : 1.0;
 }
 
 /**
@@ -7611,7 +7708,13 @@ relate_matrix(const LWGEOM *g1, const LWGEOM *g2, const RelateOperands *ops,
 bool
 meos_relate(const LWGEOM *g1, const LWGEOM *g2, char result[10])
 {
-  return relate_matrix(g1, g2, NULL, result);
+  /* The matrix is asked for on its own, so each cell extracts the edges it
+   * reads, at the scale of the pair */
+  RelateOperands ops;
+  ops.op[0].geom = g1; ops.op[0].arr = NULL;
+  ops.op[1].geom = g2; ops.op[1].arr = NULL;
+  ops.scale = relate_scale_factor(g1, g2);
+  return relate_matrix(g1, g2, &ops, result);
 }
 
 /**
@@ -8157,7 +8260,7 @@ relate_ctx_make(const LWGEOM *geom)
     return NULL;
   struct RelateCtx *ctx = palloc(sizeof(struct RelateCtx));
   ctx->op.geom = geom;
-  ctx->op.arr = relate_extract_edges(geom);
+  ctx->op.arr = relate_extract_edges(geom, 1.0);
   return ctx;
 }
 
@@ -8208,9 +8311,11 @@ meos_spatialrel_ctx(const void *ctx1, const void *ctx2, spatialRel rel,
     return true;
   }
 
+  /* Each context extracted the edges of its geometry as they are */
   RelateOperands ops;
   ops.op[0] = c1->op;
   ops.op[1] = c2->op;
+  ops.scale = 1.0;
   return relate_spatialrel_ops(&ops, rel, result);
 }
 
@@ -8245,7 +8350,7 @@ meos_spatialrel(const LWGEOM *g1, const LWGEOM *g2, spatialRel rel,
    * of a multi-surface as those of the union of its members is what a call on
    * such a geometry mostly costs, and it was paid once per step */
   RelateOperands ops;
-  relate_operands_init(&ops, g1, g2);
+  relate_operands_init(&ops, g1, g2, relate_scale_factor(g1, g2));
   bool covered = relate_spatialrel_ops(&ops, rel, result);
   relate_operands_free(&ops);
   return covered;

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -7653,9 +7653,30 @@ relate_matrix(const LWGEOM *g1, const LWGEOM *g2, const RelateOperands *ops,
 }
 
 /**
+ * @brief Return in the last argument the box a relationship reads the scale
+ * of a geometry from: the box the geometry caches, or else one computed here
+ * and not kept, so that the geometry is not written to
+ * @return False where the geometry is geodetic, whose box is geocentric and
+ * says nothing of the coordinates, where it is empty, or where no box is
+ * computed
+ */
+static bool
+relate_scale_box(const LWGEOM *geom, GBOX *box)
+{
+  if (FLAGS_GET_GEODETIC(geom->flags) || lwgeom_is_empty(geom))
+    return false;
+  if (geom->bbox)
+  {
+    *box = *geom->bbox;
+    return true;
+  }
+  return lwgeom_calculate_gbox(geom, box) == LW_SUCCESS;
+}
+
+/**
  * @brief Return the scale a relationship reads the coordinates of two
- * geometries at: the power of two bringing a joint extent below 1 into
- * [1, 2), and 1 otherwise
+ * geometries at, from their boxes: the power of two bringing a joint extent
+ * below 1 into [1, 2), and 1 otherwise
  * @details The relationship of two geometries does not change when both are
  * scaled by the same factor, and a power of two scales every coordinate
  * exactly, so the engine reading both at the scale answers as it would on the
@@ -7663,31 +7684,15 @@ relate_matrix(const LWGEOM *g1, const LWGEOM *g2, const RelateOperands *ops,
  * the shape of the edges it reads once the geometries are small against them:
  * a curve and its buffer of radius 2^-20 read as meeting outside the buffer.
  * Geometries spanning a unit or more are read as they are
- * @return 1 where either geometry is geodetic or empty, where the joint
- * extent is zero or a unit or more, or where a scaled coordinate would not be
- * finite
+ * @return 1 where the joint extent is zero or a unit or more, or where a
+ * scaled coordinate would not be finite
  */
 static double
-relate_scale_factor(const LWGEOM *g1, const LWGEOM *g2)
+relate_boxes_scale(const GBOX *b1, const GBOX *b2)
 {
-  /* A geodetic box is geocentric and says nothing of the coordinates */
-  if (FLAGS_GET_GEODETIC(g1->flags) || FLAGS_GET_GEODETIC(g2->flags) ||
-      lwgeom_is_empty(g1) || lwgeom_is_empty(g2))
-    return 1.0;
-  /* The box a geometry caches, or else one computed here and not kept, so
-   * that neither geometry is written to. The two are joined on the plane
-   * whatever dimensions each carries */
-  GBOX c1, c2;
-  if (g1->bbox)
-    c1 = *g1->bbox;
-  else if (lwgeom_calculate_gbox(g1, &c1) != LW_SUCCESS)
-    return 1.0;
-  if (g2->bbox)
-    c2 = *g2->bbox;
-  else if (lwgeom_calculate_gbox(g2, &c2) != LW_SUCCESS)
-    return 1.0;
-  double xmin = Min(c1.xmin, c2.xmin), xmax = Max(c1.xmax, c2.xmax);
-  double ymin = Min(c1.ymin, c2.ymin), ymax = Max(c1.ymax, c2.ymax);
+  /* The two boxes are joined on the plane whatever dimensions each carries */
+  double xmin = Min(b1->xmin, b2->xmin), xmax = Max(b1->xmax, b2->xmax);
+  double ymin = Min(b1->ymin, b2->ymin), ymax = Max(b1->ymax, b2->ymax);
   double ext = Max(xmax - xmin, ymax - ymin);
   if (! (ext > 0.0 && ext < 1.0))
     return 1.0;
@@ -7695,6 +7700,20 @@ relate_scale_factor(const LWGEOM *g1, const LWGEOM *g2)
   double reach = Max(Max(fabs(xmin), fabs(xmax)), Max(fabs(ymin),
     fabs(ymax)));
   return isfinite(reach * f) ? f : 1.0;
+}
+
+/**
+ * @brief Return the scale a relationship reads the coordinates of two
+ * geometries at, which #relate_boxes_scale sets from their boxes
+ * @return 1 where either geometry has no box #relate_scale_box reads
+ */
+static double
+relate_scale_factor(const LWGEOM *g1, const LWGEOM *g2)
+{
+  GBOX b1, b2;
+  if (! relate_scale_box(g1, &b1) || ! relate_scale_box(g2, &b2))
+    return 1.0;
+  return relate_boxes_scale(&b1, &b2);
 }
 
 /**
@@ -8234,20 +8253,31 @@ relate_spatialrel_ops(const RelateOperands *opsp, spatialRel rel, bool *result)
 
 /**
  * @brief The edges of one geometry, kept for every relationship asked about it
+ * @details A relationship reads its two geometries at the scale their joint
+ * extent sets (#relate_boxes_scale), so a geometry asked about against others
+ * of other sizes and places is read at more than one scale. Its edges are kept
+ * for every scale they are read at, and read at a scale only when a pair first
+ * asks for it
  */
 struct RelateCtx
 {
-  RelateOperand op;  /**< The geometry and the edges it draws */
+  const LWGEOM *geom;  /**< Geometry the edges are those of */
+  bool hasbox;         /**< True if @p box is one a scale is read from */
+  GBOX box;            /**< Box of the geometry, see #relate_scale_box */
+  int nread;           /**< Number of scales the edges are kept at */
+  int maxread;         /**< Number of scales the two arrays below hold */
+  double *scales;      /**< Scales the edges are kept at */
+  MeosArray **arrs;    /**< Edges read at each of those scales */
 };
 
 /**
- * @brief Read the edges of a geometry once, for a caller that asks about it
- * more than once
+ * @brief Keep the edges of a geometry for a caller that asks about it more
+ * than once
  * @param[in] geom Geometry
  * @return The context, or NULL where the geometry is one the engine does not
  * cover, which #meos_spatialrel_ctx then answers as uncovered
- * @note Building the context is what a relationship does at its own entry, so
- * a caller holding one pays the extraction once instead of once per pair
+ * @note A caller holding a context pays the extraction once for each scale its
+ * pairs are read at instead of once per pair
  */
 void *
 relate_ctx_make(const LWGEOM *geom)
@@ -8259,9 +8289,35 @@ relate_ctx_make(const LWGEOM *geom)
   if (geom_meos_coverage(geom) != 1)
     return NULL;
   struct RelateCtx *ctx = palloc(sizeof(struct RelateCtx));
-  ctx->op.geom = geom;
-  ctx->op.arr = relate_extract_edges(geom, 1.0);
+  ctx->geom = geom;
+  ctx->hasbox = relate_scale_box(geom, &ctx->box);
+  ctx->nread = 0;
+  ctx->maxread = 2;
+  ctx->scales = palloc(sizeof(double) * ctx->maxread);
+  ctx->arrs = palloc(sizeof(MeosArray *) * ctx->maxread);
   return ctx;
+}
+
+/**
+ * @brief Return the edges of the geometry of a context read at a scale,
+ * reading them at that scale the first time a pair asks for it
+ * @note The edges belong to the context and are released with it
+ */
+static MeosArray *
+relate_ctx_edges(struct RelateCtx *ctx, double scale)
+{
+  for (int i = 0; i < ctx->nread; i++)
+    if (ctx->scales[i] == scale)
+      return ctx->arrs[i];
+  if (ctx->nread == ctx->maxread)
+  {
+    ctx->maxread *= 2;
+    ctx->scales = repalloc(ctx->scales, sizeof(double) * ctx->maxread);
+    ctx->arrs = repalloc(ctx->arrs, sizeof(MeosArray *) * ctx->maxread);
+  }
+  ctx->scales[ctx->nread] = scale;
+  ctx->arrs[ctx->nread] = relate_extract_edges(ctx->geom, scale);
+  return ctx->arrs[ctx->nread++];
 }
 
 /**
@@ -8273,7 +8329,9 @@ relate_ctx_free(void *ctxv)
   struct RelateCtx *ctx = (struct RelateCtx *) ctxv;
   if (! ctx)
     return;
-  meos_array_destroy(ctx->op.arr);
+  for (int i = 0; i < ctx->nread; i++)
+    meos_array_destroy(ctx->arrs[i]);
+  pfree(ctx->scales); pfree(ctx->arrs);
   pfree(ctx);
   return;
 }
@@ -8286,8 +8344,10 @@ relate_ctx_free(void *ctxv)
  * @param[in] rel Relationship asked for
  * @param[out] result True if the geometries stand in the relationship
  * @return True if the pair is covered
- * @note The contexts keep owning their edges: this borrows them for the call
- * and releases nothing, so one context serves as many relationships as the
+ * @note The pair is read at the scale its joint extent sets, from the boxes
+ * the contexts keep. A context keeps the edges it reads at a scale it had not
+ * been read at, so it is written to through the handle its caller holds; it
+ * keeps owning every edge, and one context serves as many relationships as the
  * caller asks
  */
 bool
@@ -8295,8 +8355,8 @@ meos_spatialrel_ctx(const void *ctx1, const void *ctx2, spatialRel rel,
   bool *result)
 {
   assert(result);
-  const struct RelateCtx *c1 = (const struct RelateCtx *) ctx1;
-  const struct RelateCtx *c2 = (const struct RelateCtx *) ctx2;
+  struct RelateCtx *c1 = (struct RelateCtx *) ctx1;
+  struct RelateCtx *c2 = (struct RelateCtx *) ctx2;
 
   /* A geometry the engine does not cover carries no context, and the pair is
    * uncovered exactly as #meos_spatialrel reports it */
@@ -8305,17 +8365,19 @@ meos_spatialrel_ctx(const void *ctx1, const void *ctx2, spatialRel rel,
 
   /* An empty geometry holds no point to share with another, and none of the
    * four patterns admits an empty operand */
-  if (lwgeom_is_empty(c1->op.geom) || lwgeom_is_empty(c2->op.geom))
+  if (lwgeom_is_empty(c1->geom) || lwgeom_is_empty(c2->geom))
   {
     *result = false;
     return true;
   }
 
-  /* Each context extracted the edges of its geometry as they are */
   RelateOperands ops;
-  ops.op[0] = c1->op;
-  ops.op[1] = c2->op;
-  ops.scale = 1.0;
+  ops.scale = (c1->hasbox && c2->hasbox) ?
+    relate_boxes_scale(&c1->box, &c2->box) : 1.0;
+  ops.op[0].geom = c1->geom;
+  ops.op[0].arr = relate_ctx_edges(c1, ops.scale);
+  ops.op[1].geom = c2->geom;
+  ops.op[1].arr = relate_ctx_edges(c2, ops.scale);
   return relate_spatialrel_ops(&ops, rel, result);
 }
 

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -761,6 +761,63 @@ int main(void)
   assert(cov_ok == 24);
   meos_errno_reset();
 
+  /* A relationship asked from the edges a geometry keeps for many questions
+   * takes nothing from the size of the pair either. The union of that compound
+   * curve and its buffer is the buffer alone, one surface, and two circular
+   * strings that meet form one cluster, at every scale from 1 to 2^-23. Read
+   * at a fixed size, the union keeps the curve beside the buffer and the two
+   * strings fall into two clusters at 2^-22 */
+  static const double ctx_arc1[10] = {-62.23798897946629, 45.02999585785349,
+    -63.57751790698321, 44.25943553386923, -54.13401589077565,
+    47.445197838459485, -47.879089812914216, 40.968069010858905,
+    -46.17447669603102, 38.103871258761};
+  static const double ctx_arc2[10] = {-66.99138251089116, 15.92121886945246,
+    -76.03325013901814, 7.520108701258234, -69.47649951102183,
+    1.331742503837627, -67.7756956221341, 5.312985986964651,
+    -63.2930991148274, -2.6940914138737275};
+  double ctx_s = 1.0;
+  int ctx_ok = 0;
+  for (int k = 0; k >= -23; k--, ctx_s *= 0.5)
+  {
+    char curve_wkt[256];
+    snprintf(curve_wkt, sizeof curve_wkt,
+      "COMPOUNDCURVE((0 0,%.17g 0),CIRCULARSTRING(%.17g 0,%.17g %.17g,0 0))",
+      10 * ctx_s, 10 * ctx_s, 5 * ctx_s, 2 * ctx_s);
+    GSERIALIZED *curve = geom_in(curve_wkt, -1);
+    assert(curve != NULL);
+    GSERIALIZED *cbuf = geom_buffer(curve, ctx_s, "");
+    assert(cbuf != NULL);
+    GSERIALIZED *parts[2] = {cbuf, curve};
+    GSERIALIZED *cunion = geom_array_union(parts, 2);
+    assert(cunion != NULL && geo_num_geos(cunion) == 1);
+    free(cunion); free(cbuf); free(curve);
+
+    char arc_wkt[2][512];
+    const double *arcs[2] = {ctx_arc1, ctx_arc2};
+    for (int a = 0; a < 2; a++)
+    {
+      const double *c = arcs[a];
+      snprintf(arc_wkt[a], sizeof arc_wkt[a], "SRID=3812;CIRCULARSTRING("
+        "%.17g %.17g,%.17g %.17g,%.17g %.17g,%.17g %.17g,%.17g %.17g)",
+        c[0] * ctx_s, c[1] * ctx_s, c[2] * ctx_s, c[3] * ctx_s, c[4] * ctx_s,
+        c[5] * ctx_s, c[6] * ctx_s, c[7] * ctx_s, c[8] * ctx_s, c[9] * ctx_s);
+    }
+    GSERIALIZED *ga = geom_in(arc_wkt[0], -1), *gb = geom_in(arc_wkt[1], -1);
+    assert(ga != NULL && gb != NULL);
+    const GSERIALIZED *pair[2] = {ga, gb};
+    int nclusters = 0;
+    GSERIALIZED **clusters = geo_cluster_intersecting(pair, 2, &nclusters);
+    assert(clusters != NULL && nclusters == 1);
+    for (int i = 0; i < nclusters; i++)
+      free(clusters[i]);
+    free(clusters); free(ga); free(gb);
+    ctx_ok++;
+  }
+  printf("the union of a curve and its buffer is one surface, and two arcs "
+    "that meet one cluster, at %d scales from 1 to 2^-23\n", ctx_ok);
+  assert(ctx_ok == 24);
+  meos_errno_reset();
+
   /* The distance between curves is checked on the cases PostGIS gives its
    * own unit tests for the distance fixes of its 3.6 line (ticket 5989): a
    * point outside a curve polygon beside its arc, a point beside the arc of a

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -732,6 +732,35 @@ int main(void)
   assert(seg_ok == 41);
   meos_errno_reset();
 
+  /* The relationship of a curve to its own buffer takes nothing from the size
+   * of the pair. The compound curve from (0 0) to (10s 0) closed by the arc
+   * through (5s 2s), buffered by s, covers the curve, with the matrix
+   * 1F2FF1FF2, at every scale from 1 to 2^-23. A comparison against a bound of
+   * a fixed size puts a stretch of the curve outside its buffer, EI = 1, at
+   * 2^-20 and 2^-22 */
+  double cov_s = 1.0;
+  int cov_ok = 0;
+  for (int k = 0; k >= -23; k--, cov_s *= 0.5)
+  {
+    char curve_wkt[256];
+    snprintf(curve_wkt, sizeof curve_wkt,
+      "COMPOUNDCURVE((0 0,%.17g 0),CIRCULARSTRING(%.17g 0,%.17g %.17g,0 0))",
+      10 * cov_s, 10 * cov_s, 5 * cov_s, 2 * cov_s);
+    GSERIALIZED *curve = geom_in(curve_wkt, -1);
+    assert(curve != NULL);
+    GSERIALIZED *cbuf = geom_buffer(curve, cov_s, "");
+    assert(cbuf != NULL);
+    char *cm = geom_relate(cbuf, curve);
+    assert(cm != NULL && strcmp(cm, "1F2FF1FF2") == 0);
+    assert(geom_covers(cbuf, curve));
+    cov_ok++;
+    free(cm); free(cbuf); free(curve);
+  }
+  printf("the buffer of a curve covers the curve at %d scales from 1 to "
+    "2^-23\n", cov_ok);
+  assert(cov_ok == 24);
+  meos_errno_reset();
+
   /* The distance between curves is checked on the cases PostGIS gives its
    * own unit tests for the distance fixes of its 3.6 line (ticket 5989): a
    * point outside a curve polygon beside its arc, a point beside the arc of a


### PR DESCRIPTION
Answer a spatial relationship the same at every scale

The relate engine compares the edges of two geometries against bounds of a
fixed size: an arc is read as its chord where twice the area its three
points span is below 1e-12, and as a whole circle where its ends lie within
1e-12 of each other; a segment shorter than 1e-6 meets no arc; a point lies
on an edge within 1e-12 plus the rounding of its coordinates. Each bound is
right at the size it is set for and decides the shape of the edges once
the geometries are small against it, so the answer depends on the size of
the pair: the compound curve from (0 0) to (10s 0) closed by the arc through
(5s 2s) is not covered by its own buffer of radius s at s = 2^-20 and 2^-22,
the engine reading a stretch of the curve outside the buffer.

A relationship reads the coordinates of a pair whose joint extent is below a
unit at one power of two, the one bringing that extent into [1, 2). The
relationship of two geometries does not change when both are scaled by the
same factor, and a power of two scales every coordinate exactly, so the
engine answers the pair as it answers the originals, at the size its bounds
are set for. The factor is applied where the engine reads a coordinate: the
edges it builds, the points of a point geometry, and the test of a ring
enclosing no area, whose area scales by the square of the factor. An arc is
therefore read as a chord or as a circle at the scaled size, and nothing is
copied. The extent is read from the boxes the geometries cache, so a pair
spanning a unit or more costs one comparison. A geodetic geometry, whose box
is geocentric, is read as it is. The edges the buffer, the overlay and the
trajectory clip read are extracted at the factor 1.

The witness: meos/test/geo_test.c asserts that the buffer of that compound
curve covers it, with the matrix 1F2FF1FF2, at 24 scales from 1 to 2^-23.
On master the matrix reads 1F2FF11F2 at 2^-20 and 2^-22.

Measured against master: the DE-9IM matrix and the four relationships
move on none of the pairs of seven corpora (adversarial 54, arcs as
subjects 100, real curves 30, areal 1,444, real trips 202, geo pairs 12,880,
natural areas 20). The geo pairs scaled by 2^-20 and 2^-22, which stand in
the relationships the unscaled pairs stand in, move 19 and 55 answers on
master, 14 and 50 of them INTERSECTS, and none with this change. The scale
need not be a power of two: a shape lies in its own buffer, and the line
(0 0, 10s 0, 10s 5s) and the compound curve read as covered by their buffers
of radius s at s = 1e-6, which master reads as not covered. The
acceptance harness against the exact oracle reads clean and line for line
as on master (self-identity 181 of 181, the GEOS matrix 65 of 65, the
interior cell against the exact area 68 of 68). meos_spatialrel costs 0.123% more
instructions on 2,000 geo pairs scaled by 2^-10, which are all read at a
factor, 0.020% on real curves and 0.035% on the areal corpus.

The rule: a spatial relationship is invariant under a uniform scale of both
geometries, and scaling by a power of two is exact, so an answer that moves
with the scale is a comparison against a constant of fixed size.


Answer a relationship asked from kept edges at the scale of the pair

A caller asking about one geometry against many keeps its edges in a
context, and meos_spatialrel_ctx answers each pair from the edges the two
contexts keep. Those edges are read at the factor 1, so a pair answered this
way depends on its size: the union of the compound curve from (0 0) to
(10s 0) closed by the arc through (5s 2s) and its own buffer keeps the curve
beside the buffer at s = 2^-20 and 2^-22, the covering test the union asks
reading the curve as not covered, and two circular strings that meet fall
into two clusters at 2^-22.

A context keeps the box the scale is read from, and reads the edges of its
geometry at a scale the first time a pair asks for it, keeping them for
every later pair read at that scale. A pair is read at the scale its joint
extent sets, taken from the two boxes, exactly as meos_spatialrel reads it.
relate_scale_factor is split so that the box of a geometry and the scale of
two boxes are read separately.

The witness: meos/test/geo_test.c asserts that the union of the curve and
its buffer is one surface, and that two circular strings that meet form
one cluster, at 24 scales from 1 to 2^-23.

Measured against master: the geo pairs scaled by 2^-22, clustered two by
two, move 50 of 12,880 cluster answers on master and none with this change,
and the unscaled pairs move none. Clustering all 25,760 geometries of the
geo pairs scaled by 2^-10 in one call gives the 982 clusters master gives,
at 0.772% more instructions, every pair being read at a factor: reading the
edges again at other scales costs 0.5% of it, and the scale of each pair and
the lookup of the edges kept at it the rest.
The matrices and relationships meos_relate and meos_spatialrel give the geo
pairs scaled by 2^-20 and 2^-22 do not move.


